### PR TITLE
Fixed #28 - list of builds is scrollable now

### DIFF
--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/css/styles.css
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/css/styles.css
@@ -8,7 +8,10 @@ input[type=checkbox], input[type=radio] {
 
 div#buildList{
 	padding: 1em;
-	overflow:scroll;
+}
+
+div#buildPane {
+    overflow: scroll;
 }
 
 label {

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -147,7 +147,7 @@
 					    			<div id='buildPane'>
 					    				<p style="border-bottom:solid 1px #cccccc; margin:0; padding:0.5em;"><label><input name="buildTypeAll" onclick="toggleAllBuildTypesSelected();" type=checkbox style="padding-right: 1em;" class="buildType_all"><strong>All Project Builds</strong></label></p>
 					    				<p style="border-bottom:solid 1px #cccccc; margin:0; padding:0.5em;"><label><input id="buildTypeSubProjects" name="buildTypeSubProjects" onclick="updateSelectedBuildTypes();" type=checkbox style="padding-right: 1em;" class="buildType_subprojects"><strong>All Sub-Project Builds</strong></label></p>
-					            		<div id='buildList' style="overflow:auto; padding:0;">
+					            		<div id='buildList' style="padding:0;">
 						            	</div>
 						            </div>
 					    	</div><!-- panel-container  -->


### PR DESCRIPTION
This is a simple suggestion how the scrolling of a long list of builds could be fixed with minimum changes.