### PR TITLE
Add support for customizing content per notification

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
@@ -76,6 +76,15 @@ public class SlackNotificationListener extends BuildServerAdapter {
         slackNotification.setMaxCommitsToDisplay(myMainSettings.getMaxCommitsToDisplay());
         slackNotification.setMentionChannelEnabled(slackNotificationConfig.getMentionChannelEnabled());
 		slackNotification.setMentionSlackUserEnabled(slackNotificationConfig.getMentionSlackUserEnabled());
+        if(slackNotificationConfig.getContent().isEnabled()) {
+            slackNotification.setBotName(slackNotificationConfig.getContent().getBotName());
+            slackNotification.setIconUrl(slackNotificationConfig.getContent().getIconUrl());
+            slackNotification.setMaxCommitsToDisplay(slackNotificationConfig.getContent().getMaxCommitsToDisplay());
+            slackNotification.setShowBuildAgent(slackNotificationConfig.getContent().getShowBuildAgent());
+            slackNotification.setShowElapsedBuildTime(slackNotificationConfig.getContent().getShowElapsedBuildTime());
+            slackNotification.setShowCommits(slackNotificationConfig.getContent().getShowCommits());
+            slackNotification.setShowCommitters(slackNotificationConfig.getContent().getShowCommitters());
+        }
 		Loggers.ACTIVITIES.debug("SlackNotificationListener :: SlackNotification proxy set to "
 				+ slackNotification.getProxyHost() + " for " + slackNotificationConfig.getChannel());
 	}

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -26,10 +26,12 @@ public class SlackNotificationConfig {
 	private Set<String> enabledBuildTypesSet = new HashSet<String>();
     private boolean mentionChannelEnabled;
 	private boolean mentionSlackUserEnabled;
+    private boolean customContent;
+    private SlackNotificationContentConfig content;
 
     @SuppressWarnings("unchecked")
 	public SlackNotificationConfig(Element e) {
-		
+		this.content = new SlackNotificationContentConfig();
 		int Min = 1000000, Max = 1000000000;
 		Integer Rand = Min + (int)(Math.random() * ((Max - Min) + 1));
 		this.uniqueKey = Rand.toString();
@@ -121,6 +123,34 @@ public class SlackNotificationConfig {
 				}
 			}
 		}
+
+        if(e.getChild("content") != null) {
+            setHasCustomContent(true);
+            Element eContent = e.getChild("content");
+
+            if (eContent.getAttribute("iconUrl") != null){
+                this.content.setIconUrl(eContent.getAttributeValue("iconUrl"));
+            }
+            if (eContent.getAttribute("botName") != null){
+                this.content.setBotName(eContent.getAttributeValue("botName"));
+            }
+            if (eContent.getAttribute("showBuildAgent") != null){
+                this.content.setShowBuildAgent(Boolean.parseBoolean(eContent.getAttributeValue("showBuildAgent")));
+            }
+            if (eContent.getAttribute("showElapsedBuildTime") != null){
+                this.content.setShowElapsedBuildTime(Boolean.parseBoolean(eContent.getAttributeValue("showElapsedBuildTime")));
+            }
+            if (eContent.getAttribute("showCommits") != null){
+                this.content.setShowCommits(Boolean.parseBoolean(eContent.getAttributeValue("showCommits")));
+            }
+            if (eContent.getAttribute("showCommitters") != null){
+                this.content.setShowCommitters(Boolean.parseBoolean(eContent.getAttributeValue("showCommitters")));
+            }
+            if (eContent.getAttribute("maxCommitsToDisplay") != null){
+                this.content.setMaxCommitsToDisplay(Integer.parseInt(eContent.getAttributeValue("maxCommitsToDisplay")));
+            }
+        }
+
 		
 	}
 
@@ -201,6 +231,18 @@ public class SlackNotificationConfig {
 			}
 			el.addContent(templatesEl);
 		}
+
+        if(this.hasCustomContent()){
+            Element customContentEl = new Element("content");
+            customContentEl.setAttribute("iconUrl", this.content.getIconUrl());
+            customContentEl.setAttribute("botName", this.content.getBotName());
+            customContentEl.setAttribute("maxCommitsToDisplay", Integer.toString(this.content.getMaxCommitsToDisplay()));
+            customContentEl.setAttribute("showBuildAgent", this.content.getShowBuildAgent().toString());
+            customContentEl.setAttribute("showElapsedBuildTime", this.content.getShowElapsedBuildTime().toString());
+            customContentEl.setAttribute("showCommits", this.content.getShowCommits().toString());
+            customContentEl.setAttribute("showCommitters", this.content.getShowCommitters().toString());
+            el.addContent(customContentEl);
+        }
 		
 		return el;
 	}
@@ -441,4 +483,19 @@ public class SlackNotificationConfig {
 		return mentionSlackUserEnabled;
 	}
 
+    public boolean hasCustomContent() {
+        return customContent;
+    }
+
+    public void setHasCustomContent(boolean customContent) {
+        this.customContent = customContent;
+    }
+
+    public SlackNotificationContentConfig getContent() {
+        return content;
+    }
+
+    public void setContent(SlackNotificationContentConfig content) {
+        this.content = content;
+    }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -128,6 +128,8 @@ public class SlackNotificationConfig {
             setHasCustomContent(true);
             Element eContent = e.getChild("content");
 
+            this.content.setEnabled(true);
+
             if (eContent.getAttribute("iconUrl") != null){
                 this.content.setIconUrl(eContent.getAttributeValue("iconUrl"));
             }
@@ -173,6 +175,7 @@ public class SlackNotificationConfig {
 								   Set<String> enabledBuildTypes,
 								   boolean mentionChannelEnabled,
 								   boolean mentionSlackUserEnabled) {
+        this.content = new SlackNotificationContentConfig();
         int Min = 1000000, Max = 1000000000;
         Integer Rand = Min + (int) (Math.random() * ((Max - Min) + 1));
         this.uniqueKey = Rand.toString();

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
@@ -4,6 +4,11 @@ package slacknotifications.teamcity.settings;
  * Created by petegoo on 24/02/15.
  */
 public class SlackNotificationContentConfig {
+    public static final int DEFAULT_MAX_COMMITS = 5;
+    public static final boolean DEFAULT_SHOW_BUILD_AGENT = true;
+    public static final boolean DEFAULT_SHOW_ELAPSED_BUILD_TIME = true;
+    public static final boolean DEFAULT_SHOW_COMMITS = true;
+    public static final boolean DEFAULT_SHOW_COMMITTERS = true;
     private String iconUrl = SlackNotificationMainConfig.DEFAULT_ICONURL;
     private String botName = SlackNotificationMainConfig.DEFAULT_BOTNAME;
     private Boolean showBuildAgent;
@@ -11,6 +16,7 @@ public class SlackNotificationContentConfig {
     private Boolean showCommits = true;
     private Boolean showCommitters = true;
     private int maxCommitsToDisplay = 5;
+    private boolean enabled;
 
     public String getIconUrl() {
         return iconUrl;
@@ -66,5 +72,13 @@ public class SlackNotificationContentConfig {
 
     public void setMaxCommitsToDisplay(int maxCommitsToDisplay) {
         this.maxCommitsToDisplay = maxCommitsToDisplay;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationContentConfig.java
@@ -1,0 +1,70 @@
+package slacknotifications.teamcity.settings;
+
+/**
+ * Created by petegoo on 24/02/15.
+ */
+public class SlackNotificationContentConfig {
+    private String iconUrl = SlackNotificationMainConfig.DEFAULT_ICONURL;
+    private String botName = SlackNotificationMainConfig.DEFAULT_BOTNAME;
+    private Boolean showBuildAgent;
+    private Boolean showElapsedBuildTime;
+    private Boolean showCommits = true;
+    private Boolean showCommitters = true;
+    private int maxCommitsToDisplay = 5;
+
+    public String getIconUrl() {
+        return iconUrl;
+    }
+
+    public void setIconUrl(String iconUrl) {
+        this.iconUrl = iconUrl;
+    }
+
+    public String getBotName() {
+        return botName;
+    }
+
+    public void setBotName(String botName) {
+        this.botName = botName;
+    }
+
+    public Boolean getShowBuildAgent() {
+        return showBuildAgent;
+    }
+
+    public void setShowBuildAgent(Boolean showBuildAgent) {
+        this.showBuildAgent = showBuildAgent;
+    }
+
+    public Boolean getShowElapsedBuildTime() {
+        return showElapsedBuildTime;
+    }
+
+    public void setShowElapsedBuildTime(Boolean showElapsedBuildTime) {
+        this.showElapsedBuildTime = showElapsedBuildTime;
+    }
+
+    public Boolean getShowCommits() {
+        return showCommits;
+    }
+
+    public void setShowCommits(Boolean showCommits) {
+        this.showCommits = showCommits;
+    }
+
+    public Boolean getShowCommitters() {
+        return showCommitters;
+    }
+
+    public void setShowCommitters(Boolean showCommitters) {
+        this.showCommitters = showCommitters;
+    }
+
+    public int getMaxCommitsToDisplay() {
+        return maxCommitsToDisplay;
+    }
+
+    public void setMaxCommitsToDisplay(int maxCommitsToDisplay) {
+        this.maxCommitsToDisplay = maxCommitsToDisplay;
+    }
+}

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
@@ -16,7 +16,7 @@ import java.io.File;
 import java.io.IOException;
 
 public class SlackNotificationMainConfig implements ChangeListener {
-    public final String DEFAULT_BOTNAME = "TeamCity";
+    public static final String DEFAULT_BOTNAME = "TeamCity";
     public static final String DEFAULT_ICONURL = "https://raw.githubusercontent.com/PeteGoo/tcSlackBuildNotifier/master/docs/TeamCity32.png";
 
 
@@ -38,19 +38,14 @@ public class SlackNotificationMainConfig implements ChangeListener {
 	
 	public final String SINGLE_HOST_REGEX = "^[^./~`'\"]+(?:/.*)?$";
 	public final String HOSTNAME_ONLY_REGEX = "^([^/]+)(?:/.*)?$";
-    private String iconUrl = DEFAULT_ICONURL;
-    private String botName = DEFAULT_BOTNAME;
-    private Boolean showBuildAgent;
-    private Boolean showElapsedBuildTime;
-    private Boolean showCommits = true;
-    private Boolean showCommitters = true;
-    private int maxCommitsToDisplay = 5;
-	private boolean configFileExists;
+    private SlackNotificationContentConfig content;
+    private boolean configFileExists;
+
 
 
 
 	public SlackNotificationMainConfig(ServerPaths serverPaths) {
-
+        this.content = new SlackNotificationContentConfig();
 		this.myConfigDir = new File(serverPaths.getConfigDir(), "slack");
 		this.myConfigFile = new File(this.myConfigDir, "slack-config.xml");
         configFileExists = this.myConfigFile.exists();
@@ -186,26 +181,6 @@ public class SlackNotificationMainConfig implements ChangeListener {
         this.token = token;
     }
 
-    public String getIconUrl()
-    {
-        return iconUrl;
-    }
-
-    public void setIconUrl(String iconUrl)
-    {
-        this.iconUrl = iconUrl;
-    }
-
-    public String getBotName()
-    {
-        return botName;
-    }
-
-    public void setBotName(String botName)
-    {
-        this.botName = botName;
-    }
-	
 	public Integer getProxyPort() {
 		return proxyPort;
 	}
@@ -279,46 +254,6 @@ public class SlackNotificationMainConfig implements ChangeListener {
 	}
 
 
-    public Boolean getShowBuildAgent() {
-        return showBuildAgent;
-    }
-
-    public void setShowBuildAgent(Boolean showBuildAgent) {
-        this.showBuildAgent = showBuildAgent;
-    }
-
-    public Boolean getShowElapsedBuildTime() {
-        return showElapsedBuildTime;
-    }
-
-    public void setShowElapsedBuildTime(Boolean showElapsedBuildTime) {
-        this.showElapsedBuildTime = showElapsedBuildTime;
-    }
-
-    public boolean getShowCommits() {
-        return showCommits;
-    }
-
-    public void setShowCommits(boolean showCommits) {
-        this.showCommits = showCommits;
-    }
-	
-    public boolean getShowCommitters() {
-        return showCommitters;
-    }
-	
-    public void setShowCommitters(boolean showCommitters) {
-        this.showCommitters = showCommitters;
-    }
-
-    public int getMaxCommitsToDisplay() {
-        return maxCommitsToDisplay;
-    }
-
-    public void setMaxCommitsToDisplay(int maxCommitsToDisplay) {
-        this.maxCommitsToDisplay = maxCommitsToDisplay;
-    }
-
 	public synchronized void save()
 	{
 		this.myChangeObserver.runActionWithDisabledObserver(new Runnable()
@@ -332,21 +267,21 @@ public class SlackNotificationMainConfig implements ChangeListener {
 						rootElement.setAttribute("defaultChannel", emptyIfNull(SlackNotificationMainConfig.this.defaultChannel));
                         rootElement.setAttribute("teamName", emptyIfNull(SlackNotificationMainConfig.this.teamName));
 						rootElement.setAttribute("token", emptyIfNull(SlackNotificationMainConfig.this.token));
-						rootElement.setAttribute("iconurl", emptyIfNull(SlackNotificationMainConfig.this.iconUrl));
-						rootElement.setAttribute("botname", emptyIfNull(SlackNotificationMainConfig.this.botName));
-						if(SlackNotificationMainConfig.this.showBuildAgent != null){
-							rootElement.setAttribute("showBuildAgent", Boolean.toString(SlackNotificationMainConfig.this.showBuildAgent));
+						rootElement.setAttribute("iconurl", emptyIfNull(SlackNotificationMainConfig.this.content.getIconUrl()));
+						rootElement.setAttribute("botname", emptyIfNull(SlackNotificationMainConfig.this.content.getBotName()));
+						if(SlackNotificationMainConfig.this.content.getShowBuildAgent() != null){
+							rootElement.setAttribute("showBuildAgent", Boolean.toString(SlackNotificationMainConfig.this.content.getShowBuildAgent()));
 						}
-						if(SlackNotificationMainConfig.this.showElapsedBuildTime != null) {
-							rootElement.setAttribute("showElapsedBuildTime", Boolean.toString(SlackNotificationMainConfig.this.showElapsedBuildTime));
+						if(SlackNotificationMainConfig.this.content.getShowElapsedBuildTime() != null) {
+							rootElement.setAttribute("showElapsedBuildTime", Boolean.toString(SlackNotificationMainConfig.this.content.getShowElapsedBuildTime()));
 						}
-						if(SlackNotificationMainConfig.this.showCommits != null) {
-							rootElement.setAttribute("showCommits", Boolean.toString(SlackNotificationMainConfig.this.showCommits));
+						if(SlackNotificationMainConfig.this.content.getShowCommits() != null) {
+							rootElement.setAttribute("showCommits", Boolean.toString(SlackNotificationMainConfig.this.content.getShowCommits()));
 						}
-						if(SlackNotificationMainConfig.this.showCommitters != null) {
-							rootElement.setAttribute("showCommitters", Boolean.toString(SlackNotificationMainConfig.this.showCommitters));
+						if(SlackNotificationMainConfig.this.content.getShowCommitters() != null) {
+							rootElement.setAttribute("showCommitters", Boolean.toString(SlackNotificationMainConfig.this.content.getShowCommitters()));
 						}
-						rootElement.setAttribute("maxCommitsToDisplay", Integer.toString(SlackNotificationMainConfig.this.maxCommitsToDisplay));
+						rootElement.setAttribute("maxCommitsToDisplay", Integer.toString(SlackNotificationMainConfig.this.content.getMaxCommitsToDisplay()));
 
                         rootElement.removeChildren("proxy");
                         rootElement.removeChildren("info");
@@ -404,31 +339,31 @@ public class SlackNotificationMainConfig implements ChangeListener {
             }
             if(slackNotificationsElement.getAttribute("iconurl") != null)
             {
-                setIconUrl(slackNotificationsElement.getAttributeValue("iconurl"));
+                content.setIconUrl(slackNotificationsElement.getAttributeValue("iconurl"));
             }
             if(slackNotificationsElement.getAttribute("botname") != null)
             {
-                setBotName(slackNotificationsElement.getAttributeValue("botname"));
+                content.setBotName(slackNotificationsElement.getAttributeValue("botname"));
             }
             if(slackNotificationsElement.getAttribute("showBuildAgent") != null)
             {
-                setShowBuildAgent(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue("showBuildAgent")));
+                content.setShowBuildAgent(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue("showBuildAgent")));
             }
             if(slackNotificationsElement.getAttribute("showElapsedBuildTime") != null)
             {
-                setShowElapsedBuildTime(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue("showElapsedBuildTime")));
+                content.setShowElapsedBuildTime(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue("showElapsedBuildTime")));
             }
             if(slackNotificationsElement.getAttribute("showCommits") != null)
             {
-                setShowCommits(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue("showCommits")));
+                content.setShowCommits(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue("showCommits")));
             }
             if(slackNotificationsElement.getAttribute("showCommitters") != null)
             {
-                setShowCommitters(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue("showCommitters")));
+                content.setShowCommitters(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue("showCommitters")));
             }
             if(slackNotificationsElement.getAttribute("maxCommitsToDisplay") != null)
             {
-                setMaxCommitsToDisplay(Integer.parseInt(slackNotificationsElement.getAttributeValue("maxCommitsToDisplay")));
+                content.setMaxCommitsToDisplay(Integer.parseInt(slackNotificationsElement.getAttributeValue("maxCommitsToDisplay")));
             }
 
             Element proxyElement = slackNotificationsElement.getChild("proxy");
@@ -465,5 +400,9 @@ public class SlackNotificationMainConfig implements ChangeListener {
 
     public SlackNotificationProxyConfig getProxyConfig() {
         return new SlackNotificationProxyConfig(proxyHost, proxyPort, proxyUsername, proxyPassword);
+    }
+
+    public SlackNotificationContentConfig getContent() {
+        return content;
     }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
@@ -321,6 +321,7 @@ public class SlackNotificationMainConfig implements ChangeListener {
 
 	void readConfigurationFromXmlElement(Element slackNotificationsElement) {
         if(slackNotificationsElement != null){
+            content.setEnabled(true);
             if(slackNotificationsElement.getAttribute("enabled") != null)
             {
                 setEnabled(Boolean.parseBoolean(slackNotificationsElement.getAttributeValue("enabled")));

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
@@ -91,12 +91,12 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
 
     public String getIconUrl()
     {
-        return this.slackNotificationMainConfig.getIconUrl();
+        return this.slackNotificationMainConfig.getContent().getIconUrl();
     }
 
     public String getBotName()
     {
-        return this.slackNotificationMainConfig.getBotName();
+        return this.slackNotificationMainConfig.getContent().getBotName();
     }
 
     public boolean getEnabled(){
@@ -105,19 +105,19 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
 
 
     public Boolean getShowBuildAgent() {
-        return this.slackNotificationMainConfig.getShowBuildAgent();
+        return this.slackNotificationMainConfig.getContent().getShowBuildAgent();
     }
 
     public Boolean getShowElapsedBuildTime() {
-        return this.slackNotificationMainConfig.getShowElapsedBuildTime();
+        return this.slackNotificationMainConfig.getContent().getShowElapsedBuildTime();
     }
 
     public boolean getShowCommits(){
-        return this.slackNotificationMainConfig.getShowCommits();
+        return this.slackNotificationMainConfig.getContent().getShowCommits();
     }
 	
     public boolean getShowCommitters(){
-        return this.slackNotificationMainConfig.getShowCommitters();
+        return this.slackNotificationMainConfig.getContent().getShowCommitters();
     }
 
     public Boolean getSlackNotificationShowFurtherReading(){
@@ -133,7 +133,7 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
 
 
     public int getMaxCommitsToDisplay() {
-        return this.slackNotificationMainConfig.getMaxCommitsToDisplay();
+        return this.slackNotificationMainConfig.getContent().getMaxCommitsToDisplay();
     }
 
     public void refresh() {

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -72,7 +72,6 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
 				Loggers.SERVER.debug(NAME + ":writeTo :: channel " + whc.getChannel());
 				Loggers.SERVER.debug(NAME + ":writeTo :: enabled " + String.valueOf(whc.getEnabled()));
             }
-
         }
     }
     
@@ -130,7 +129,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
         }    	
     }
 
-	public void updateSlackNotification(String ProjectId, String slackNotificationId, String channel, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled) {
+	public void updateSlackNotification(String ProjectId, String slackNotificationId, String channel, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, SlackNotificationContentConfig content) {
         if(this.slackNotificationsConfigs != null)
         {
         	updateSuccess = false;
@@ -145,6 +144,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
                 	whc.setBuildStates(buildState);
                 	whc.enableForSubProjects(buildSubProjects);
                 	whc.enableForAllBuildsInProject(buildTypeAll);
+                    whc.setContent(content);
                 	if (!buildTypeAll){
                 		whc.clearAllEnabledBuildsInProject();
                 		for (String bt : buildTypesEnabled){

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -144,6 +144,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
                 	whc.setBuildStates(buildState);
                 	whc.enableForSubProjects(buildSubProjects);
                 	whc.enableForAllBuildsInProject(buildTypeAll);
+                    whc.setHasCustomContent(content.isEnabled());
                     whc.setContent(content);
                 	if (!buildTypeAll){
                 		whc.clearAllEnabledBuildsInProject();

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
@@ -1,5 +1,6 @@
 package slacknotifications.teamcity.settings;
 
+import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,8 +9,7 @@ import slacknotifications.testframework.util.ConfigLoaderUtil;
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class SlackNotificationConfigTest {
 	
@@ -19,15 +19,17 @@ public class SlackNotificationConfigTest {
 	SlackNotificationConfig slacknotificationAllDisabled;
 	SlackNotificationConfig slacknotificationDisabled;
 	SlackNotificationConfig slacknotificationMostEnabled;
-	
-	
-	@Before
+    SlackNotificationConfig slacknotificationCustomContent;
+
+
+    @Before
 	public void setup() throws JDOMException, IOException{
 		
 		slacknotificationAllEnabled  = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-all-states-enabled.xml"));
 		slacknotificationAllDisabled = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-all-states-disabled.xml"));
 		slacknotificationDisabled    = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-slacknotifications-disabled.xml"));
 		slacknotificationMostEnabled = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-all-but-respchange-states-enabled.xml"));
+        slacknotificationCustomContent = ConfigLoaderUtil.getFirstSlackNotificationInConfig(new File("src/test/resources/project-settings-test-custom-content.xml"));
 	}
 	
 //	private SlackNotificationConfig getFirstSlackNotificationInConfig(File f) throws JDOMException, IOException{
@@ -157,5 +159,39 @@ public class SlackNotificationConfigTest {
 		assertFalse(slacknotificationAllDisabled.getStateBuildBrokenAsChecked().equals(CHECKED));
 	}
 
+    @Test
+    public void loading_config_when_custom_content_section_is_present_sets_customContentEnabled(){
+        assertTrue(slacknotificationCustomContent.hasCustomContent());
+    }
+
+    @Test
+    public void loading_config_when_custom_content_section_is_not_present_does_not_set_customContentEnabled(){
+        assertFalse(slacknotificationMostEnabled.hasCustomContent());
+    }
+
+    @Test
+    public void loading_config_when_custom_content_section_is_present_sets_customContent(){
+        assertNotSame(SlackNotificationMainConfig.DEFAULT_BOTNAME, slacknotificationCustomContent.getContent().getBotName());
+        assertNotSame(SlackNotificationMainConfig.DEFAULT_ICONURL, slacknotificationCustomContent.getContent().getIconUrl());
+        assertTrue(slacknotificationCustomContent.getContent().getShowBuildAgent());
+        assertTrue(slacknotificationCustomContent.getContent().getShowElapsedBuildTime());
+        assertTrue(slacknotificationCustomContent.getContent().getShowCommits());
+        assertTrue(slacknotificationCustomContent.getContent().getShowElapsedBuildTime());
+        assertEquals(20, slacknotificationCustomContent.getContent().getMaxCommitsToDisplay());
+    }
+
+    @Test
+    public void getAsElement_when_custom_content_sets_customContent(){
+        Element e = slacknotificationCustomContent.getAsElement();
+        SlackNotificationConfig config = new SlackNotificationConfig(e);
+        assertTrue(config.hasCustomContent());
+        assertNotSame(SlackNotificationMainConfig.DEFAULT_BOTNAME, slacknotificationCustomContent.getContent().getBotName());
+        assertNotSame(SlackNotificationMainConfig.DEFAULT_ICONURL, slacknotificationCustomContent.getContent().getIconUrl());
+        assertTrue(slacknotificationCustomContent.getContent().getShowBuildAgent());
+        assertTrue(slacknotificationCustomContent.getContent().getShowElapsedBuildTime());
+        assertTrue(slacknotificationCustomContent.getContent().getShowCommits());
+        assertTrue(slacknotificationCustomContent.getContent().getShowElapsedBuildTime());
+        assertEquals(20, slacknotificationCustomContent.getContent().getMaxCommitsToDisplay());
+    }
 
 }

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-test-custom-content.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-test-custom-content.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+  <slackNotifications enabled="true">
+    <slackNotification channel="http://localhost/test" enabled="true" format="nvpairs">
+      <states>
+        <state type="buildStarted" enabled="true" />
+      </states>
+        <content iconUrl="http://my.url.com/my-icon.png"
+                 botName="TeamCity2"
+                 showBuildAgent="true"
+                 showElapsedBuildTime="true"
+                 showCommits="true"
+                 showCommitters="true"
+                 maxCommitsToDisplay="20" />
+    </slackNotification>
+  </slackNotifications>
+</settings>
+

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
@@ -210,8 +210,8 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 			    						} else {
 			    							projSettings.updateSlackNotification(myProject.getProjectId(),request.getParameter("slackNotificationId"),
 			    														request.getParameter("channel"), enabled,
-			    														states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled, mentionSlackUserEnabled,
-                                                                        content);
+			    														states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled,
+                                                                        mentionSlackUserEnabled, content);
 			    							if(projSettings.updateSuccessful()){
 			    								myProject.persist();
 			    	    						params.put("messages", "<errors />");

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxSettingsListPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxSettingsListPageController.java
@@ -13,6 +13,7 @@ import slacknotifications.teamcity.TeamCityIdResolver;
 import slacknotifications.teamcity.extension.bean.ProjectSlackNotificationsBean;
 import slacknotifications.teamcity.extension.bean.ProjectSlackNotificationsBeanJsonSerialiser;
 import slacknotifications.teamcity.payload.SlackNotificationPayloadManager;
+import slacknotifications.teamcity.settings.SlackNotificationMainSettings;
 import slacknotifications.teamcity.settings.SlackNotificationProjectSettings;
 
 import javax.servlet.http.HttpServletRequest;
@@ -22,20 +23,24 @@ import java.util.HashMap;
 
 public class SlackNotificationAjaxSettingsListPageController extends BaseController {
 
-	    private final WebControllerManager myWebManager;
-	    private SBuildServer myServer;
-	    private ProjectSettingsManager mySettings;
-	    private PluginDescriptor myPluginDescriptor;
-	    private final SlackNotificationPayloadManager myManager;
+	private final WebControllerManager myWebManager;
+    private final SlackNotificationMainSettings myMainSettings;
+
+    private SBuildServer myServer;
+	private ProjectSettingsManager mySettings;
+	private PluginDescriptor myPluginDescriptor;
+	private final SlackNotificationPayloadManager myManager;
 
 	    public SlackNotificationAjaxSettingsListPageController(SBuildServer server, WebControllerManager webManager,
-                                                               ProjectSettingsManager settings, SlackNotificationPayloadManager manager, PluginDescriptor pluginDescriptor) {
+                                                               ProjectSettingsManager settings, SlackNotificationPayloadManager manager, PluginDescriptor pluginDescriptor,
+                                                               SlackNotificationMainSettings mainSettings) {
 	        super(server);
 	        myWebManager = webManager;
 	        myServer = server;
 	        mySettings = settings;
 	        myPluginDescriptor = pluginDescriptor;
 	        myManager = manager;
+            myMainSettings = mainSettings;
 	    }
 
 	    public void register(){
@@ -55,7 +60,7 @@ public class SlackNotificationAjaxSettingsListPageController extends BaseControl
 		    	SlackNotificationProjectSettings projSettings = (SlackNotificationProjectSettings)
 		    			mySettings.getSettings(request.getParameter("projectId"), "slackNotifications");
 		    	
-		    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project)));
+		    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project, myMainSettings)));
 	        } else if (request.getParameter("buildTypeId") != null){
         		SBuildType sBuildType = TeamCityIdResolver.findBuildTypeById(this.myServer.getProjectManager(), request.getParameter("buildTypeId"));
         		if (sBuildType != null){
@@ -63,7 +68,7 @@ public class SlackNotificationAjaxSettingsListPageController extends BaseControl
 		        	if (project != null){
 				    	SlackNotificationProjectSettings projSettings = (SlackNotificationProjectSettings)
 				    			mySettings.getSettings(project.getProjectId(), "slackNotifications");
-		        		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, sBuildType, project)));
+		        		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, sBuildType, project, myMainSettings)));
 		        	}
         		}
 	        

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationIndexPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationIndexPageController.java
@@ -99,14 +99,14 @@ public class SlackNotificationIndexPageController extends BaseController {
 			    	if (projSettings.getSlackNotificationsCount() == 0){
 			    		params.put("noSlackNotifications", "true");
 			    		params.put("slackNotifications", "false");
-			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project)));
+			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project, myMainSettings)));
 			    	} else {
 			    		params.put("noSlackNotifications", "false");
 			    		params.put("slackNotifications", "true");
 			    		params.put("slackNotificationList", projSettings.getSlackNotificationsAsList());
 			    		params.put("slackNotificationsDisabled", !projSettings.isEnabled());
 			    		params.put("slackNotificationsEnabledAsChecked", projSettings.isEnabledAsChecked());
-			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project)));
+			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project, myMainSettings)));
 
 			    	}
 		    	} else {
@@ -139,7 +139,7 @@ public class SlackNotificationIndexPageController extends BaseController {
 			    		params.put("noSlackNotifications", configs.size() == 0);
 			    		params.put("slackNotifications", configs.size() != 0);
 				    	
-			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, sBuildType, project)));
+			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, sBuildType, project, myMainSettings)));
 		        	}
         		} else {
 		    		params.put("haveProject", "false");

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotifierSettingsController.java
@@ -233,14 +233,14 @@ public class SlackNotifierSettingsController extends BaseController {
 
         this.config.setTeamName(teamName);
         this.config.setToken(token);
-        this.config.setBotName(botName);
-        this.config.setIconUrl(iconUrl);
+        this.config.getContent().setBotName(botName);
+        this.config.getContent().setIconUrl(iconUrl);
         this.config.setDefaultChannel(defaultChannel);
-        this.config.setMaxCommitsToDisplay(Integer.parseInt(maxCommitsToDisplay));
-        this.config.setShowBuildAgent(Boolean.parseBoolean(showBuildAgent));
-        this.config.setShowCommits(Boolean.parseBoolean(showCommits));
-        this.config.setShowCommitters(Boolean.parseBoolean(showCommitters));
-        this.config.setShowElapsedBuildTime((Boolean.parseBoolean(showElapsedBuildTime)));
+        this.config.getContent().setMaxCommitsToDisplay(Integer.parseInt(maxCommitsToDisplay));
+        this.config.getContent().setShowBuildAgent(Boolean.parseBoolean(showBuildAgent));
+        this.config.getContent().setShowCommits(Boolean.parseBoolean(showCommits));
+        this.config.getContent().setShowCommitters(Boolean.parseBoolean(showCommitters));
+        this.config.getContent().setShowElapsedBuildTime((Boolean.parseBoolean(showElapsedBuildTime)));
 
 
         this.config.setProxyHost(proxyHost);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
@@ -5,6 +5,7 @@ import jetbrains.buildServer.serverSide.SProject;
 import slacknotifications.teamcity.BuildState;
 import slacknotifications.teamcity.TeamCityIdResolver;
 import slacknotifications.teamcity.settings.SlackNotificationConfig;
+import slacknotifications.teamcity.settings.SlackNotificationMainSettings;
 import slacknotifications.teamcity.settings.SlackNotificationProjectSettings;
 
 import java.util.*;
@@ -14,7 +15,7 @@ public class ProjectSlackNotificationsBean {
 	Map<String, SlacknotificationConfigAndBuildTypeListHolder> slackNotificationList;
 	
 	
-	public static ProjectSlackNotificationsBean build(SlackNotificationProjectSettings projSettings, SProject project){
+	public static ProjectSlackNotificationsBean build(SlackNotificationProjectSettings projSettings, SProject project, SlackNotificationMainSettings mainSettings){
 		ProjectSlackNotificationsBean bean = new ProjectSlackNotificationsBean();
 		List<SBuildType> projectBuildTypes = TeamCityIdResolver.getOwnBuildTypes(project);
 		
@@ -25,18 +26,18 @@ public class ProjectSlackNotificationsBean {
 		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", true, new BuildState().setAllEnabled(), true, true, null, true, true);
 		newBlankConfig.setUniqueKey("new");
 		/* And add it to the list */
-		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig);
+		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig, mainSettings);
 		
 		/* Iterate over the rest of the slacknotifications in this project and add them to the json config */
 		for (SlackNotificationConfig config : projSettings.getSlackNotificationsAsList()){
-			addSlackNotificationConfigHolder(bean, projectBuildTypes, config);
+			addSlackNotificationConfigHolder(bean, projectBuildTypes, config, mainSettings);
 		}
 		
 		return bean;
 		
 	}
 	
-	public static ProjectSlackNotificationsBean build(SlackNotificationProjectSettings projSettings, SBuildType sBuildType, SProject project){
+	public static ProjectSlackNotificationsBean build(SlackNotificationProjectSettings projSettings, SBuildType sBuildType, SProject project, SlackNotificationMainSettings mainSettings){
 		ProjectSlackNotificationsBean bean = new ProjectSlackNotificationsBean();
 		List<SBuildType> projectBuildTypes = TeamCityIdResolver.getOwnBuildTypes(project);
 		Set<String> enabledBuildTypes = new HashSet<String>();
@@ -49,11 +50,11 @@ public class ProjectSlackNotificationsBean {
 		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", true, new BuildState().setAllEnabled(), false, false, enabledBuildTypes, true, true);
 		newBlankConfig.setUniqueKey("new");
 		/* And add it to the list */
-		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig);
+		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig, mainSettings);
 		
 		/* Iterate over the rest of the slacknotifications in this project and add them to the json config */
 		for (SlackNotificationConfig config : projSettings.getBuildSlackNotificationsAsList(sBuildType)){
-			addSlackNotificationConfigHolder(bean, projectBuildTypes, config);
+			addSlackNotificationConfigHolder(bean, projectBuildTypes, config, mainSettings);
 		}
 		
 		return bean;
@@ -62,8 +63,8 @@ public class ProjectSlackNotificationsBean {
 
 
 	private static void addSlackNotificationConfigHolder(ProjectSlackNotificationsBean bean,
-			List<SBuildType> projectBuildTypes, SlackNotificationConfig config) {
-		SlacknotificationConfigAndBuildTypeListHolder holder = new SlacknotificationConfigAndBuildTypeListHolder(config);
+			List<SBuildType> projectBuildTypes, SlackNotificationConfig config, SlackNotificationMainSettings mainSettings) {
+		SlacknotificationConfigAndBuildTypeListHolder holder = new SlacknotificationConfigAndBuildTypeListHolder(config, mainSettings);
 		for (SBuildType sBuildType : projectBuildTypes){
 			holder.addSlackNotificationBuildType(new SlacknotificationBuildTypeEnabledStatusBean(
 													sBuildType.getBuildTypeId(), 

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
@@ -2,12 +2,15 @@ package slacknotifications.teamcity.extension.bean;
 
 import slacknotifications.teamcity.BuildStateEnum;
 import slacknotifications.teamcity.settings.SlackNotificationConfig;
+import slacknotifications.teamcity.settings.SlackNotificationContentConfig;
+import slacknotifications.teamcity.settings.SlackNotificationMainConfig;
+import slacknotifications.teamcity.settings.SlackNotificationMainSettings;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class SlacknotificationConfigAndBuildTypeListHolder {
-	public String channel;
+    public String channel;
 	public String uniqueKey; 
 	public boolean enabled;
 	public String payloadFormatForWeb = "Unknown";
@@ -19,8 +22,16 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
 	private String enabledBuildsListForWeb;
 	private boolean mentionChannelEnabled;
 	private boolean mentionSlackUserEnabled;
-	
-	public SlacknotificationConfigAndBuildTypeListHolder(SlackNotificationConfig config) {
+    private boolean customContentEnabled;
+    private boolean showBuildAgent;
+    private boolean showElapsedBuildTime;
+    private boolean showCommits;
+    private boolean showCommitters;
+    private int maxCommitsToDisplay;
+    private String botName;
+    private String iconUrl;
+
+	public SlacknotificationConfigAndBuildTypeListHolder(SlackNotificationConfig config, SlackNotificationMainSettings mainSettings) {
 		channel = config.getChannel();
 		uniqueKey = config.getUniqueKey();
 		enabled = config.getEnabled();
@@ -33,6 +44,14 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
 		}
 		mentionChannelEnabled = config.getMentionChannelEnabled();
 		mentionSlackUserEnabled = config.getMentionSlackUserEnabled();
+        maxCommitsToDisplay = config.getContent().getMaxCommitsToDisplay();
+        customContentEnabled = config.getContent().isEnabled();
+        showBuildAgent = valueOrFallback(config.getContent().getShowBuildAgent(), valueOrFallback(mainSettings.getShowBuildAgent(), SlackNotificationContentConfig.DEFAULT_SHOW_BUILD_AGENT));
+        showElapsedBuildTime = valueOrFallback(config.getContent().getShowElapsedBuildTime(), valueOrFallback(mainSettings.getShowElapsedBuildTime(), SlackNotificationContentConfig.DEFAULT_SHOW_ELAPSED_BUILD_TIME));
+        showCommits = valueOrFallback(config.getContent().getShowCommits(), valueOrFallback(mainSettings.getShowCommits(), SlackNotificationContentConfig.DEFAULT_SHOW_COMMITS));
+        showCommitters = valueOrFallback(config.getContent().getShowCommitters(), valueOrFallback(mainSettings.getShowCommitters(), SlackNotificationContentConfig.DEFAULT_SHOW_COMMITTERS));
+        botName = valueOrFallback(config.getContent().getBotName(), SlackNotificationMainConfig.DEFAULT_BOTNAME);
+        iconUrl = valueOrFallback(config.getContent().getIconUrl(), SlackNotificationMainConfig.DEFAULT_ICONURL);
 	}
 
 	public List<SlacknotificationBuildTypeEnabledStatusBean> getBuilds() {
@@ -49,6 +68,14 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
 		return types.toString();
 		
 	}
+
+    private boolean valueOrFallback(Boolean value, boolean fallback){
+        return value == null ? fallback : value.booleanValue();
+    }
+
+    private String valueOrFallback(String value, String fallback){
+        return value == null ? fallback : value;
+    }
 
 	public void setBuilds(List<SlacknotificationBuildTypeEnabledStatusBean> builds) {
 		this.builds = builds;

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
@@ -137,6 +137,14 @@
 					});
 					jQuerySlacknotification('#mentionChannelEnabled').attr('checked', slacknotification.mentionChannelEnabled);
 					jQuerySlacknotification('#mentionSlackUserEnabled').attr('checked', slacknotification.mentionSlackUserEnabled);
+					jQuerySlacknotification('#maxCommitsToDisplay').val(slacknotification.maxCommitsToDisplay);
+					jQuerySlacknotification('#customContentEnabled').attr('checked', slacknotification.customContentEnabled);
+					jQuerySlacknotification('#showBuildAgent').attr('checked', slacknotification.showBuildAgent);
+					jQuerySlacknotification('#showCommits').attr('checked', slacknotification.showCommits);
+					jQuerySlacknotification('#showCommitters').attr('checked', slacknotification.showCommitters);
+					jQuerySlacknotification('#showElapsedBuildTime').attr('checked', slacknotification.showElapsedBuildTime);
+					jQuerySlacknotification('#botName').val(slacknotification.botName);
+					jQuerySlacknotification('#iconUrl').val(slacknotification.iconUrl)
 				}
 			});
 			updateSelectedBuildTypes();

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
@@ -80,6 +80,16 @@
 				jQuerySlacknotification('tr.onBuildFailed td input').attr('disabled', 'disabled');
 			}
 		}
+
+		function toggleCustomContentEnabled(){
+            if(jQuerySlacknotification('#customContentEnabled').is(':checked')){
+                jQuerySlacknotification('.onCustomContentEnabled').removeClass('onCompletionDisabled');
+                jQuerySlacknotification('tr.onCustomContentEnabled td input').removeAttr('disabled');
+            } else {
+                jQuerySlacknotification('.onCustomContentEnabled').addClass('onCompletionDisabled');
+                jQuerySlacknotification('tr.onCustomContentEnabled td input').attr('disabled', 'disabled');
+            }
+		}
 		
 		function toggleAllBuildTypesSelected(){
 			jQuerySlacknotification.each(jQuerySlacknotification('.buildType_single'), function(){
@@ -163,6 +173,7 @@
 			    
 			    populateSlackNotificationDialog(id);
 			    doExtraCompleted();
+			    toggleCustomContentEnabled();
 			    
 			    var title = id == "new" ? "Add New" : "Edit";
 			    title += " SlackNotification";

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -200,9 +200,24 @@
                                                </td>
                                                <td colspan="2">
                                                    <input type="text" name="maxCommitsToDisplay" id="maxCommitsToDisplay" />
-                                                   <span class="smallNote">The maximum number of commits to display.</span>
                                                </td>
                                            </tr>
+                                           <tr class="onCustomContentEnabled">
+                                              <td>
+                                                  <label for="botName">Bot name: <l:star /></label>
+                                              </td>
+                                              <td colspan="2">
+                                                  <input type="text" name="botName" id="botName" />
+                                              </td>
+                                          </tr>
+                                          <tr class="onCustomContentEnabled">
+                                                <td>
+                                                    <label for="iconUrl">Icon Url: <l:star /></label>
+                                                </td>
+                                                <td colspan="2">
+                                                    <input type="text" name="iconUrl" id="iconUrl" />
+                                                </td>
+                                            </tr>
                                         </table>
 
                                 </div>

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -62,7 +62,8 @@
             
             		<div id="tab-container" class="tab-container">
 								  <ul class='etabs'>
-												   <li class='tab'><a href="#hookPane" class="active">Slack Config</a></li>
+												   <li class='tab'><a href="#hookPane" class="active">General</a></li>
+												   <li class='tab'><a href="#payloadPane" class="active">Content</a></li>
 												   <li class='tab'><a href="#buildPane">Builds (<span id="selectedBuildCount">all</span>)</a></li>
 								  </ul>
 						 <div class='panel-container'>
@@ -143,6 +144,68 @@
 					    					</table>     
 					    					
 					    			</div><!--hookPane -->
+					    			<div id='payloadPane'>
+                                        <table style="border:none;">
+                                            <tr style="border:none;">
+                                                <td><label for="slackNotificationsEnabled">Customize contents:</label></td>
+                                                <td style="padding-left:3px;" colspan=2><input id="customContentEnabled" type=checkbox name="customContentEnabled" onclick="toggleCustomContentEnabled();"/></td>
+                                            </tr>
+                                           <tr class="onCustomContentEnabled">
+                                               <td>
+                                                   <label for="showBuildAgent">Show build agent: </label>
+                                               </td>
+                                               <td>
+                                                   <input type="checkbox" name="showBuildAgent" id="showBuildAgent" />
+                                               </td>
+                                               <td>
+                                                   <span style="color: #888; font-size: 90%;">When checked, the name of the build agent will be shown in the notification.</span>
+                                               </td>
+                                           </tr>
+                                           <tr class="onCustomContentEnabled">
+                                               <td>
+                                                   <label for="showElapsedBuildTime">Show elapsed build time: </label>
+                                               </td>
+                                               <td>
+                                                   <input type="checkbox" name="showElapsedBuildTime" id="showElapsedBuildTime" />
+                                               </td>
+                                               <td>
+                                                   <span style="color: #888; font-size: 90%;">When checked, the elapsed time taken to complete the build is displayed in the notification.</span>
+                                               </td>
+                                           </tr>
+                                           <tr class="onCustomContentEnabled">
+                                               <td>
+                                                   <label for="showCommitters">Show committers: </label>
+                                               </td>
+                                               <td>
+                                                   <input type="checkbox" name="showCommitters" id="showCommitters"/>
+                                               </td>
+                                               <td>
+                                                   <span style="color: #888; font-size: 90%;">When checked, the committers responsible for the changes in the build will be displayed in the notification.</span>
+                                               </td>
+                                           </tr>
+                                           <tr class="onCustomContentEnabled">
+                                               <td>
+                                                   <label for="showCommits">Show commits: </label>
+                                               </td>
+                                               <td>
+                                                   <input type="checkbox" name="showCommits" id="showCommits" />
+                                               </td>
+                                               <td>
+                                                   <span style="color: #888; font-size: 90%;">When checked, the commits, the username and the commit message for each change will be displayed in the notification.</span>
+                                               </td>
+                                           </tr>
+                                           <tr class="onCustomContentEnabled">
+                                               <td>
+                                                   <label for="maxCommitsToDisplay">Max commits to display: <l:star /></label>
+                                               </td>
+                                               <td colspan="2">
+                                                   <input type="text" name="maxCommitsToDisplay" id="maxCommitsToDisplay" />
+                                                   <span class="smallNote">The maximum number of commits to display.</span>
+                                               </td>
+                                           </tr>
+                                        </table>
+
+                                </div>
 					    			
 					    			<div id='buildPane'>
 					    				<p style="border-bottom:solid 1px #cccccc; margin:0; padding:0.5em;"><label><input name="buildTypeAll" onclick="toggleAllBuildTypesSelected();" type=checkbox style="padding-right: 1em;" class="buildType_all"><strong>All Project Builds</strong></label></p>

--- a/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBeanTest.java
+++ b/tcslackbuildnotifier-web-ui/src/test/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBeanTest.java
@@ -1,8 +1,11 @@
 package slacknotifications.teamcity.extension.bean;
 
+import jetbrains.buildServer.serverSide.SBuildServer;
+import jetbrains.buildServer.serverSide.ServerPaths;
 import org.jdom.JDOMException;
 import org.junit.Test;
 import slacknotifications.teamcity.BuildStateEnum;
+import slacknotifications.teamcity.settings.SlackNotificationMainSettings;
 import slacknotifications.testframework.SlackNotificationMockingFramework;
 import slacknotifications.testframework.SlackNotificationMockingFrameworkImpl;
 
@@ -11,24 +14,31 @@ import java.io.IOException;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import static org.mockito.Mockito.mock;
+
 public class ProjectSlackNotificationsBeanTest {
 
 	SortedMap<String, String> map = new TreeMap<String, String>();
 	SlackNotificationMockingFramework framework;
+    SBuildServer sBuildServer = mock(SBuildServer.class);
 
 	@Test
 	public void JsonSerialisationTest() throws JDOMException, IOException {
-		framework = SlackNotificationMockingFrameworkImpl.create(BuildStateEnum.BUILD_FINISHED);
+        ServerPaths serverPaths = mock(ServerPaths.class);
+        SlackNotificationMainSettings myMainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
+        framework = SlackNotificationMockingFrameworkImpl.create(BuildStateEnum.BUILD_FINISHED);
 		framework.loadSlackNotificationProjectSettingsFromConfigXml(new File("../tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-specific-builds.xml"));
-		ProjectSlackNotificationsBean slacknotificationsConfig = ProjectSlackNotificationsBean.build(framework.getSlackNotificationProjectSettings() ,framework.getServer().getProjectManager().findProjectById("project01"));
+		ProjectSlackNotificationsBean slacknotificationsConfig = ProjectSlackNotificationsBean.build(framework.getSlackNotificationProjectSettings() , framework.getServer().getProjectManager().findProjectById("project01"), myMainSettings);
 		System.out.println(ProjectSlackNotificationsBeanJsonSerialiser.serialise(slacknotificationsConfig));
 	}
 	
 	@Test
 	public void JsonBuildSerialisationTest() throws JDOMException, IOException {
-		framework = SlackNotificationMockingFrameworkImpl.create(BuildStateEnum.BUILD_FINISHED);
+        ServerPaths serverPaths = mock(ServerPaths.class);
+        SlackNotificationMainSettings myMainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
+        framework = SlackNotificationMockingFrameworkImpl.create(BuildStateEnum.BUILD_FINISHED);
 		framework.loadSlackNotificationProjectSettingsFromConfigXml(new File("../tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-specific-builds.xml"));
-		ProjectSlackNotificationsBean slacknotificationsConfig = ProjectSlackNotificationsBean.build(framework.getSlackNotificationProjectSettings() ,framework.getSBuildType() ,framework.getServer().getProjectManager().findProjectById("project01"));
+		ProjectSlackNotificationsBean slacknotificationsConfig = ProjectSlackNotificationsBean.build(framework.getSlackNotificationProjectSettings() ,framework.getSBuildType() ,framework.getServer().getProjectManager().findProjectById("project01"), myMainSettings);
 		System.out.println(ProjectSlackNotificationsBeanJsonSerialiser.serialise(slacknotificationsConfig));
 	}
 


### PR DESCRIPTION
Currently if you want to change the content settings of the notification (show build agent, show commits / committers etc) then you have to change them globally.

This PR adds the ability to customise these settings per notification / build.

You can now customize:
- Show Elapsed Build Time
- Show Build Agent
- Show Commits
- Show Committers
- Max Commits to Display
- Bot Name
- Icon Url
