### PR TITLE
Avoid duplicate committer names

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 
@@ -334,7 +335,7 @@ public class SlackNotificationImpl implements SlackNotification {
         slackUsers = new ArrayList<String>(tempHash);
 
         if(showCommitters) {
-            List<String> committers = new ArrayList<String>();
+            Set<String> committers = new HashSet<String>();
             for (Commit commit : commits) {
                 committers.add(commit.getUserName());
             }


### PR DESCRIPTION
This PR makes it so the committers string does not contain duplicates. As it stands now, you may see something like:

> Changes By
 sdozor, sdozor, sdozor

This situation is made much worse when you have a lot of commits/committers - you end up with a committer string that is extremely long and kinda useless. With this change it should just look like this:

> Changes By
 sdozor