### PR TITLE
squid:S1858  "toString()" should never be called on a String object

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/TestListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/TestListener.java
@@ -64,7 +64,7 @@ public class TestListener extends BuildServerAdapter {
 		try {
 			newUser = newValue.getResponsibleUser().getDescriptiveName();
 		} catch (Exception e) {}
-		logit("Build " + bt.getFullName().toString()
+		logit("Build " + bt.getFullName() 
 				+ " has changed responsibility from " 
 				+ oldUser + " to " + newUser);
 	}

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/SlackNotificationPayloadManager.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/SlackNotificationPayloadManager.java
@@ -59,13 +59,13 @@ public class SlackNotificationPayloadManager {
             newUser = responsibilityInfoNew.getResponsibleUser().getDescriptiveName();
         } catch (Exception e) {}
 
-        content.setText(buildType.getFullName().toString()
+        content.setText(buildType.getFullName() 
                         + " changed responsibility from "
                         + oldUser
                         + " to "
                         + newUser
                         + " with comment '"
-                        + responsibilityInfoNew.getComment().toString().trim()
+                        + responsibilityInfoNew.getComment().trim()
                         + "'"
         );
 
@@ -89,13 +89,13 @@ public class SlackNotificationPayloadManager {
         }
 
 
-        content.setText(buildType.getFullName().toString().toString().trim()
+        content.setText(buildType.getFullName().trim()
                         + " changed responsibility from "
                         + oldUser
                         + " to "
                         + newUser
                         + " with comment '"
-                        + responsibilityEntryNew.getComment().toString().trim()
+                        + responsibilityEntryNew.getComment().trim()
                         + "'"
         );
 

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
@@ -167,7 +167,7 @@ public class SlackNotificationPayloadContent {
 		 * @param state
 		 */
 		private void populateCommonContent(SBuildServer server, SBuildType buildType, BuildStateEnum state) {
-			setBuildFullName(buildType.getFullName().toString());
+			setBuildFullName(buildType.getFullName());
 			setBuildName(buildType.getName());
 			setBuildTypeId(TeamCityIdResolver.getBuildTypeId(buildType));
 			setBuildStatusUrl(server.getRootUrl() + "/viewLog.html?buildTypeId=" + buildType.getBuildTypeId() + "&buildId=lastFinished");
@@ -196,7 +196,7 @@ public class SlackNotificationPayloadContent {
     private void populateCommonContent(SBuildServer server, SRunningBuild sRunningBuild, SFinishedBuild previousBuild,
                                        BuildStateEnum buildState) {
         setBuildResult(sRunningBuild, previousBuild, buildState);
-        setBuildFullName(sRunningBuild.getBuildType().getFullName().toString());
+        setBuildFullName(sRunningBuild.getBuildType().getFullName());
         setBuildName(sRunningBuild.getBuildType().getName());
         setBuildId(Long.toString(sRunningBuild.getBuildId()));
         setBuildTypeId(TeamCityIdResolver.getBuildTypeId(sRunningBuild.getBuildType()));
@@ -217,7 +217,7 @@ public class SlackNotificationPayloadContent {
         }
         setBuildStatusUrl(server.getRootUrl() + "/viewLog.html?buildTypeId=" + getBuildTypeId() + "&buildId=" + getBuildId());
         String branchSuffix = (getBranchIsDefault() != null && getBranchIsDefault()) || getBranchDisplayName() == null ? "" : (" [" + getBranchDisplayName() + "]");
-        setBuildDescriptionWithLinkSyntax(String.format("<" + getBuildStatusUrl() + "|" + getBuildResult() + " - " + sRunningBuild.getBuildType().getFullName().toString() + " #" + sRunningBuild.getBuildNumber() + branchSuffix + ">"));
+        setBuildDescriptionWithLinkSyntax(String.format("<" + getBuildStatusUrl() + "|" + getBuildResult() + " - " + sRunningBuild.getBuildType().getFullName() + " #" + sRunningBuild.getBuildNumber() + branchSuffix + ">"));
     }
 		
 		

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
@@ -293,14 +293,14 @@ public class SlackNotificationMainConfig implements ChangeListener {
 								&& getProxyPort() != null && getProxyPort() > 0 )
 						{
 							rootElement.addContent(getProxyAsElement());
-							Loggers.SERVER.debug(SlackNotificationMainConfig.class.getName() + "writeTo :: proxyHost " + getProxyHost().toString());
-							Loggers.SERVER.debug(SlackNotificationMainConfig.class.getName() + "writeTo :: proxyPort " + getProxyPort().toString());
+							Loggers.SERVER.debug(SlackNotificationMainConfig.class.getName() + "writeTo :: proxyHost " + getProxyHost());
+							Loggers.SERVER.debug(SlackNotificationMainConfig.class.getName() + "writeTo :: proxyPort " + getProxyPort());
 						}
 
 						if(getInfoUrlAsElement() != null){
                             rootElement.addContent(getInfoUrlAsElement());
-							Loggers.SERVER.debug(SlackNotificationMainConfig.class.getName() + "writeTo :: infoText " + getSlackNotificationInfoText().toString());
-							Loggers.SERVER.debug(SlackNotificationMainConfig.class.getName() + "writeTo :: InfoUrl  " + getSlackNotificationInfoUrl().toString());
+							Loggers.SERVER.debug(SlackNotificationMainConfig.class.getName() + "writeTo :: infoText " + getSlackNotificationInfoText());
+							Loggers.SERVER.debug(SlackNotificationMainConfig.class.getName() + "writeTo :: InfoUrl  " + getSlackNotificationInfoUrl());
 							Loggers.SERVER.debug(SlackNotificationMainConfig.class.getName() + "writeTo :: show-reading  " + getSlackNotificationShowFurtherReading().toString());
 						}
 					}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1858 - “""toString()"" should never be called on a String object”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1858
 Please let me know if you have any questions.
Fevzi Ozgul