### PR TITLE
Fixing squid:S1118 - Utility classes should not have public constructors.

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/Loggers.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/Loggers.java
@@ -3,6 +3,8 @@ package slacknotifications.teamcity;
 import com.intellij.openapi.diagnostic.Logger;
 
 public final class Loggers {
+	
+	private Loggers(){}
 	public static final Logger SERVER 		= Logger.getInstance("jetbrains.buildServer.SERVER");
 	public static final Logger ACTIVITIES  	= Logger.getInstance("jetbrains.buildServer.ACTIVITIES");
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/TeamCityIdResolver.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/TeamCityIdResolver.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 public final class TeamCityIdResolver {
 	
+	private TeamCityIdResolver(){}
+	
 	public static String getBuildTypeId(SBuildType buildType){
 		try {
 			return buildType.getExternalId();

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/converter/OldStyleBuildState.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/converter/OldStyleBuildState.java
@@ -10,6 +10,8 @@ public final class OldStyleBuildState {
     
     public static final Integer ALL_ENABLED				= Integer.parseInt("11111111",2);
     
+    
+    private OldStyleBuildState(){}
     /**
      * Takes the currentBuildState, for which the SlackNotification is being triggered
      * and compares it against the build states for which this SlackNotification is configured

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/converter/SlackNotificationBuildStateConverter.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/converter/SlackNotificationBuildStateConverter.java
@@ -5,6 +5,8 @@ import slacknotifications.teamcity.BuildStateEnum;
 
 public class SlackNotificationBuildStateConverter {
 
+	private SlackNotificationBuildStateConverter(){}
+	
 	public static BuildState convert(Integer oldState){
 		BuildState newStates = new BuildState();
 		

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBeanJsonSerialiser.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBeanJsonSerialiser.java
@@ -4,7 +4,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.json.JsonHierarchicalStreamDriver;
 
 public class ProjectSlackNotificationsBeanJsonSerialiser {
-	
+	private ProjectSlackNotificationsBeanJsonSerialiser(){}
 	public static String serialise(ProjectSlackNotificationsBean project){
 		XStream xstream = new XStream(new JsonHierarchicalStreamDriver());
         xstream.setMode(XStream.NO_REFERENCES);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.

Fevzi Ozgul