### PR TITLE
Fixing squid:S1155 Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
@@ -118,7 +118,7 @@ public class SlackNotificationPayloadContent {
         for(BuildProblemData reason : failureReasons){
             if(reason.getType() == BuildProblemData.TC_FAILED_TESTS_TYPE){
                 List<TestInfo> failedTestMessages = sRunningBuild.getTestMessages(0, 2000);
-                if(failedTestMessages.size() > 0) {
+                if(!failedTestMessages.isEmpty()) {
                     for (TestInfo failedTest : failedTestMessages) {
                         failureTestNames.add(failedTest.getName());
                     }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -72,7 +72,7 @@ public class SlackNotificationConfig {
 		if(e.getChild("states") != null){
 			Element eStates = e.getChild("states");
 			List<Element> statesList = eStates.getChildren("state");
-			if (statesList.size() > 0){
+			if (!statesList.isEmpty()){
 				for(Element eState : statesList)
 				{
 					try {
@@ -97,7 +97,7 @@ public class SlackNotificationConfig {
 			}
 			if (!isEnabledForAllBuildsInProject()){
 				List<Element> typesList = eTypes.getChildren("build-type");
-				if (typesList.size() > 0){
+				if (!typesList.isEmpty()){
 					for(Element eType : typesList)
 					{
 						if (eType.getAttributeValue("id")!= null){
@@ -113,7 +113,7 @@ public class SlackNotificationConfig {
 		if(e.getChild("custom-templates") != null){
 			Element eParams = e.getChild("custom-templates");
 			List<Element> templateList = eParams.getChildren("custom-template");
-			if (templateList.size() > 0){
+			if (!templateList.isEmpty()){
 				for(Element eParam : templateList)
 				{
 					this.templates.put(
@@ -227,7 +227,7 @@ public class SlackNotificationConfig {
 		buildsEl.setAttribute("enabled-for-all", Boolean.toString(isEnabledForAllBuildsInProject()));
 		buildsEl.setAttribute("enabled-for-subprojects", Boolean.toString(isEnabledForSubProjects()));
 		
-		if (this.enabledBuildTypesSet.size() > 0){
+		if (!this.enabledBuildTypesSet.isEmpty()){
 			for (String i : enabledBuildTypesSet){
 				Element e = new Element("build-type");
 				e.setAttribute("id", i);

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -40,7 +40,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
     	}
     	
 		List<Element> namedChildren = rootElement.getChildren("slackNotification");
-        if(namedChildren.size() == 0)
+        if(namedChildren.isEmpty())
         {
             this.slackNotificationsConfigs = null;
         } else {
@@ -122,7 +122,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
                 	tempSlackNotificationList.add(whc);
                 }
             }
-            if (tempSlackNotificationList.size() > 0){
+            if (!tempSlackNotificationList.isEmpty()){
             	this.updateSuccess = true;
             	this.slackNotificationsConfigs.removeAll(tempSlackNotificationList);
             }

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationIndexPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationIndexPageController.java
@@ -136,8 +136,8 @@ public class SlackNotificationIndexPageController extends BaseController {
 				    	params.put("buildName", sBuildType.getName());
 				    	params.put("buildExternalId", TeamCityIdResolver.getExternalBuildId(sBuildType));
 				    	params.put("buildTypeList", project.getBuildTypes());
-			    		params.put("noSlackNotifications", configs.size() == 0);
-			    		params.put("slackNotifications", configs.size() != 0);
+			    		params.put("noSlackNotifications", configs.isEmpty());
+			    		params.put("slackNotifications", !configs.isEmpty());
 				    	
 			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, sBuildType, project, myMainSettings)));
 		        	}

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/BuildSlacknotificationsBean.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/BuildSlacknotificationsBean.java
@@ -33,15 +33,15 @@ public class BuildSlacknotificationsBean{
 	}
 	
 	public boolean hasBuilds(){
-		return this.buildConfigs.size() > 0;
+		return !this.buildConfigs.isEmpty();
 	}
 	
 	public boolean hasNoBuildSlackNotifications(){
-		return this.buildConfigs.size() == 0;
+		return this.buildConfigs.isEmpty();
 	}
 	
 	public boolean hasBuildSlackNotifications(){
-		return this.buildConfigs.size() > 0;
+		return !this.buildConfigs.isEmpty();
 	}
 	
 	public int getBuildCount(){


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1155
 Please let me know if you have any questions.
Fevzi Ozgul