### PR TITLE
Fixing squid:ClassVariableVisibilityCheck  Class variable fields should not have public accessibility

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
@@ -346,13 +346,28 @@ public class SlackNotificationListener extends BuildServerAdapter {
 	 */
 	
 	private class SlackNotificationConfigWrapper {
-		public SlackNotification slackNotification;
-		public SlackNotificationConfig whc;
+		 
+		private SlackNotification slackNotification;
+		
+		private SlackNotificationConfig whc;
 		
 		public SlackNotificationConfigWrapper(SlackNotification slackNotification, SlackNotificationConfig slackNotificationConfig) {
 			this.slackNotification = slackNotification;
 			this.whc = slackNotificationConfig;
 		}
+		 public void setSlackNotification(SlackNotification slackNotification){
+			 this.slackNotification=slackNotification;
+		 }
+		 public SlackNotification getSlackNotification(){
+			 return slackNotification;
+		 }
+		 
+		 public void setSlackNotificationConfig(SlackNotificationConfig whc){
+			 this.whc=whc;
+		 }
+		 public SlackNotificationConfig getSlackNotificationConfig(){
+			 return whc;
+		 }
 	}
 
 }

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
@@ -73,6 +73,6 @@ public class ProjectSlackNotificationsBean {
 													)
 										);
 		}
-		bean.slackNotificationList.put(holder.uniqueKey, holder);
+		bean.slackNotificationList.put(holder.getUniqueKey(), holder);
 	}
 }

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
@@ -10,14 +10,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SlacknotificationConfigAndBuildTypeListHolder {
-    public String token;
-	public String channel;
-	public String uniqueKey; 
-	public boolean enabled;
-	public String payloadFormatForWeb = "Unknown";
-	public List<StateBean> states = new ArrayList<StateBean>();
-	public boolean allBuildTypesEnabled;
-	public boolean subProjectsEnabled;
+   
+
+	private String token;
+	private String channel;
+	private String uniqueKey; 
+	private boolean enabled;
+	private String payloadFormatForWeb = "Unknown";
+	private List<StateBean> states = new ArrayList<StateBean>();
+	private boolean allBuildTypesEnabled;
+	private boolean subProjectsEnabled;
+	
+	
+	
+	
 	private List<SlacknotificationBuildTypeEnabledStatusBean> builds = new ArrayList<SlacknotificationBuildTypeEnabledStatusBean>();
 	private String enabledEventsListForWeb;
 	private String enabledBuildsListForWeb;
@@ -58,6 +64,71 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
         iconUrl = valueOrFallback(config.getContent().getIconUrl(), SlackNotificationMainConfig.DEFAULT_ICONURL);
 	}
 
+	
+	 public String getToken() {
+			return token;
+		}
+
+		public void setToken(String token) {
+			this.token = token;
+		}
+
+		public String getChannel() {
+			return channel;
+		}
+
+		public void setChannel(String channel) {
+			this.channel = channel;
+		}
+
+		public String getUniqueKey() {
+			return uniqueKey;
+		}
+
+		public void setUniqueKey(String uniqueKey) {
+			this.uniqueKey = uniqueKey;
+		}
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public String getPayloadFormatForWeb() {
+			return payloadFormatForWeb;
+		}
+
+		public void setPayloadFormatForWeb(String payloadFormatForWeb) {
+			this.payloadFormatForWeb = payloadFormatForWeb;
+		}
+
+		public List<StateBean> getStates() {
+			return states;
+		}
+
+		public void setStates(List<StateBean> states) {
+			this.states = states;
+		}
+
+		public boolean isAllBuildTypesEnabled() {
+			return allBuildTypesEnabled;
+		}
+
+		public void setAllBuildTypesEnabled(boolean allBuildTypesEnabled) {
+			this.allBuildTypesEnabled = allBuildTypesEnabled;
+		}
+
+		public boolean isSubProjectsEnabled() {
+			return subProjectsEnabled;
+		}
+
+		public void setSubProjectsEnabled(boolean subProjectsEnabled) {
+			this.subProjectsEnabled = subProjectsEnabled;
+		}
+	
 	public List<SlacknotificationBuildTypeEnabledStatusBean> getBuilds() {
 		return builds;
 	}

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/StateBean.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/StateBean.java
@@ -1,10 +1,26 @@
 package slacknotifications.teamcity.extension.bean;
 public class StateBean{
-	public String buildStateName;
-	public boolean enabled;
+	private String buildStateName;
+	private boolean enabled;
 	
 	public StateBean(String name1, boolean enabled1) {
 		this.buildStateName = name1;
 		this.enabled = enabled1;
+	}
+
+	public String getBuildStateName() {
+		return buildStateName;
+	}
+
+	public void setBuildStateName(String buildStateName) {
+		this.buildStateName = buildStateName;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving of occurrences of Squid :" class variable fields should not have public accessibility" . 
"Public class variable fields do not respect the encapsulation principle and has three main disadvantages:
Additional behavior such as validation cannot be added.
The internal representation is exposed, and cannot be changed afterwards.
Member values are subject to change from anywhere in the code and may not meet the programmer's assumptions.
By using private attributes and accessor methods (set and get), unauthorized modifications are prevented."

Fevzi Ozgul