### PR TITLE
Fixing squid: S1192 String literals should not be duplicated part 2

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/SlackNotificationPayloadManager.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/SlackNotificationPayloadManager.java
@@ -14,7 +14,8 @@ import java.util.Collection;
 
 public class SlackNotificationPayloadManager {
 
-    SBuildServer server;
+    private static final String NOBODY = "nobody";
+	SBuildServer server;
 
     public SlackNotificationPayloadManager(SBuildServer server){
         this.server = server;
@@ -50,8 +51,8 @@ public class SlackNotificationPayloadManager {
                                      ResponsibilityInfo responsibilityInfoNew, boolean isUserAction) {
 
         SlackNotificationPayloadContent content = new SlackNotificationPayloadContent(server, buildType, BuildStateEnum.RESPONSIBILITY_CHANGED);
-        String oldUser = "Nobody";
-        String newUser = "Nobody";
+        String oldUser = NOBODY;
+        String newUser = NOBODY;
         try {
             oldUser = responsibilityInfoOld.getResponsibleUser().getDescriptiveName();
         } catch (Exception e) {}
@@ -79,8 +80,8 @@ public class SlackNotificationPayloadManager {
                                      ResponsibilityEntry responsibilityEntryNew) {
 
         SlackNotificationPayloadContent content = new SlackNotificationPayloadContent(server, buildType, BuildStateEnum.RESPONSIBILITY_CHANGED);
-        String oldUser = "Nobody";
-        String newUser = "Nobody";
+        String oldUser = NOBODY;
+        String newUser = NOBODY;
         if (responsibilityEntryOld.getState() != ResponsibilityEntry.State.NONE) {
             oldUser = responsibilityEntryOld.getResponsibleUser().getDescriptiveName();
         }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/util/SlackNotificationBeanUtilsVariableResolver.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/util/SlackNotificationBeanUtilsVariableResolver.java
@@ -18,6 +18,8 @@ import java.lang.reflect.InvocationTargetException;
 
 public class SlackNotificationBeanUtilsVariableResolver implements VariableResolver {
 	
+	private static final String EXCEPTION_MESSAGE = " thrown when trying to resolve value for ";
+	
 	Object bean;
 	
 	public SlackNotificationBeanUtilsVariableResolver(Object javaBean) {
@@ -30,13 +32,13 @@ public class SlackNotificationBeanUtilsVariableResolver implements VariableResol
 		try {
 			value = (String) PropertyUtils.getProperty(bean, variableName);
 		} catch (IllegalAccessException e) {
-			Loggers.SERVER.warn(this.getClass().getSimpleName() + " :: " + e.getClass() + " thrown when trying to resolve value for " + variableName); 
+			Loggers.SERVER.warn(this.getClass().getSimpleName() + " :: " + e.getClass() + EXCEPTION_MESSAGE + variableName); 
 			Loggers.SERVER.debug(e);
 		} catch (InvocationTargetException e) {
-			Loggers.SERVER.warn(this.getClass().getSimpleName() + " :: " + e.getClass() + " thrown when trying to resolve value for " + variableName); 
+			Loggers.SERVER.warn(this.getClass().getSimpleName() + " :: " + e.getClass() + EXCEPTION_MESSAGE + variableName); 
 			Loggers.SERVER.debug(e);
 		} catch (NoSuchMethodException e) {
-			Loggers.SERVER.warn(this.getClass().getSimpleName() + " :: " + e.getClass() + " thrown when trying to resolve value for " + variableName); 
+			Loggers.SERVER.warn(this.getClass().getSimpleName() + " :: " + e.getClass() + EXCEPTION_MESSAGE + variableName); 
 			Loggers.SERVER.debug(e);
 		}
 		return value;

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 
 public class SlackNotificationProjectSettings implements ProjectSettings {
+	private static final String ENABLED = "enabled";
 	private static final String NAME = SlackNotificationProjectSettings.class.getName();
 	ProjectSettingsManager psm;
 	ProjectSettings ps;
@@ -35,8 +36,8 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
     	Loggers.SERVER.debug("readFrom :: " + rootElement.toString());
     	CopyOnWriteArrayList<SlackNotificationConfig> configs = new CopyOnWriteArrayList<SlackNotificationConfig>();
     	
-    	if (rootElement.getAttribute("enabled") != null){
-    		this.slackNotificationsEnabled = Boolean.parseBoolean(rootElement.getAttributeValue("enabled"));
+    	if (rootElement.getAttribute(ENABLED) != null){
+    		this.slackNotificationsEnabled = Boolean.parseBoolean(rootElement.getAttributeValue(ENABLED));
     	}
     	
 		List<Element> namedChildren = rootElement.getChildren("slackNotification");
@@ -62,7 +63,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
      */
     {
     	Loggers.SERVER.debug(NAME + ":writeTo :: " + parentElement.toString());
-    	parentElement.setAttribute("enabled", String.valueOf(this.slackNotificationsEnabled));
+    	parentElement.setAttribute(ENABLED, String.valueOf(this.slackNotificationsEnabled));
         if(slackNotificationsConfigs != null)
         {
             for(SlackNotificationConfig whc : slackNotificationsConfigs){

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxSettingsListPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxSettingsListPageController.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 
 
 public class SlackNotificationAjaxSettingsListPageController extends BaseController {
+	
+	private static final String PROJECT_ID = "projectId";
 
 	private final WebControllerManager myWebManager;
     private final SlackNotificationMainSettings myMainSettings;
@@ -53,12 +55,12 @@ public class SlackNotificationAjaxSettingsListPageController extends BaseControl
 	        HashMap<String,Object> params = new HashMap<String,Object>();
 	        params.put("jspHome",this.myPluginDescriptor.getPluginResourcesPath());
 	        
-	        if(request.getParameter("projectId") != null 
-	        		&& request.getParameter("projectId").startsWith("project")){
+	        if(request.getParameter(PROJECT_ID) != null 
+	        		&& request.getParameter(PROJECT_ID).startsWith("project")){
 	        	
-	        	SProject project = this.myServer.getProjectManager().findProjectById(request.getParameter("projectId"));
+	        	SProject project = this.myServer.getProjectManager().findProjectById(request.getParameter(PROJECT_ID));
 		    	SlackNotificationProjectSettings projSettings = (SlackNotificationProjectSettings)
-		    			mySettings.getSettings(request.getParameter("projectId"), "slackNotifications");
+		    			mySettings.getSettings(request.getParameter(PROJECT_ID), "slackNotifications");
 		    	
 		    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project, myMainSettings)));
 	        } else if (request.getParameter("buildTypeId") != null){

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationBuildTabExtension.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationBuildTabExtension.java
@@ -20,7 +20,10 @@ import java.util.List;
 import java.util.Map;
 
 
+
 public class SlackNotificationBuildTabExtension extends BuildTypeTab {
+	
+	private static final String  SLACK_NOTIFICATIONS = "slackNotifications";
 	SlackNotificationProjectSettings settings;
 	ProjectSettingsManager projSettings;
 	String myPluginPath;
@@ -30,7 +33,7 @@ public class SlackNotificationBuildTabExtension extends BuildTypeTab {
             ProjectSettingsManager settings, WebControllerManager manager,
             PluginDescriptor pluginDescriptor) {
 		//super(myTitle, myTitle, null, projectManager);
-		super("slackNotifications", "Slack", manager, projectManager);
+		super(SLACK_NOTIFICATIONS, "Slack", manager, projectManager);
 		this.projSettings = settings;
 		myPluginPath = pluginDescriptor.getPluginResourcesPath();
 	}
@@ -44,7 +47,7 @@ public class SlackNotificationBuildTabExtension extends BuildTypeTab {
 	protected void fillModel(Map model, HttpServletRequest request,
 			 @NotNull SBuildType buildType, SUser user) {
 		this.settings = 
-			(SlackNotificationProjectSettings)this.projSettings.getSettings(buildType.getProject().getProjectId(), "slackNotifications");
+			(SlackNotificationProjectSettings)this.projSettings.getSettings(buildType.getProject().getProjectId(), SLACK_NOTIFICATIONS);
 		
 		List<ProjectAndBuildSlacknotificationsBean> projectAndParents = new ArrayList<ProjectAndBuildSlacknotificationsBean>();
 		List<SProject> parentProjects = buildType.getProject().getProjectPath();
@@ -53,7 +56,7 @@ public class SlackNotificationBuildTabExtension extends BuildTypeTab {
 			projectAndParents.add(
 					ProjectAndBuildSlacknotificationsBean.newInstance(
 							projectParent,
-							(SlackNotificationProjectSettings) this.projSettings.getSettings(projectParent.getProjectId(), "slackNotifications"),
+							(SlackNotificationProjectSettings) this.projSettings.getSettings(projectParent.getProjectId(), SLACK_NOTIFICATIONS),
 							buildType
 							)
 					);
@@ -62,7 +65,7 @@ public class SlackNotificationBuildTabExtension extends BuildTypeTab {
 //		projectAndParents.add(
 //				ProjectAndBuildSlacknotificationsBean.newInstance(
 //						project,
-//						(SlackNotificationProjectSettings) this.projSettings.getSettings(project.getProjectId(), "slackNotifications"),
+//						(SlackNotificationProjectSettings) this.projSettings.getSettings(project.getProjectId(), SLACK_NOTIFICATIONS),
 //						true
 //						)
 //				);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationIndexPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationIndexPageController.java
@@ -28,7 +28,15 @@ import java.util.List;
 
 public class SlackNotificationIndexPageController extends BaseController {
 
-	    private final WebControllerManager myWebManager;
+		private static final String SHOW_FURTHER_READING = "ShowFurtherReading";
+		private static final String SLACK_NOTIFICATIONS = "slackNotifications";
+		private static final String NO_SLACK_NOTIFICATIONS = "noSlackNotifications";
+		private static final String PROJECT_ID = "projectId";
+		private static final String FALSE = "false";
+		private static final String ERROR_REASON = "errorReason";
+		private static final String PROJECT_SLACK_NOTIFICATION_AS_JSON = "projectSlackNotificationsAsJson";
+		
+		private final WebControllerManager myWebManager;
 	    private final SlackNotificationMainSettings myMainSettings;
 	    private SBuildServer myServer;
 	    private ProjectSettingsManager mySettings;
@@ -62,23 +70,23 @@ public class SlackNotificationIndexPageController extends BaseController {
 	    	if (myMainSettings.getInfoUrl() != null && myMainSettings.getInfoUrl().length() > 0){
 	    		params.put("moreInfoText", "<li><a href=\"" + myMainSettings.getInfoUrl() + "\">" + myMainSettings.getInfoText() + "</a></li>");
 	    		if (myMainSettings.getSlackNotificationShowFurtherReading()){
-	    			params.put("ShowFurtherReading", "ALL");
+	    			params.put(SHOW_FURTHER_READING, "ALL");
 	    		} else {
-	    			params.put("ShowFurtherReading", "SINGLE");
+	    			params.put(SHOW_FURTHER_READING, "SINGLE");
 	    		}
 	    	} else if (myMainSettings.getSlackNotificationShowFurtherReading()){
-	    		params.put("ShowFurtherReading", "DEFAULT");
+	    		params.put(SHOW_FURTHER_READING, "DEFAULT");
 	    	} else {
-	    		params.put("ShowFurtherReading", "NONE");
+	    		params.put(SHOW_FURTHER_READING, "NONE");
 	    	}
 	        
-	        if(request.getParameter("projectId") != null){
+	        if(request.getParameter(PROJECT_ID) != null){
 	        	
 	        	SProject project = TeamCityIdResolver.findProjectById(this.myServer.getProjectManager(), request.getParameter("projectId"));
 	        	if (project != null){
 	        		
 			    	SlackNotificationProjectSettings projSettings = (SlackNotificationProjectSettings)
-			    			mySettings.getSettings(project.getProjectId(), "slackNotifications");
+			    			mySettings.getSettings(project.getProjectId(), SLACK_NOTIFICATIONS);
 			    	
 			        SUser myUser = SessionUser.getUser(request);
 			        params.put("hasPermission", myUser.isPermissionGrantedForProject(project.getProjectId(), Permission.EDIT_PROJECT));
@@ -87,7 +95,7 @@ public class SlackNotificationIndexPageController extends BaseController {
 			    	
 			    	params.put("haveProject", "true");
 			    	params.put("messages", message);
-			    	params.put("projectId", project.getProjectId());
+			    	params.put(PROJECT_ID, project.getProjectId());
 			    	params.put("buildTypeList", project.getBuildTypes());
 			    	params.put("projectExternalId", TeamCityIdResolver.getExternalProjectId(project));
 			    	params.put("projectName", project.getName());
@@ -97,21 +105,21 @@ public class SlackNotificationIndexPageController extends BaseController {
 			    	params.put("slackNotificationCount", projSettings.getSlackNotificationsCount());
 			    	
 			    	if (projSettings.getSlackNotificationsCount() == 0){
-			    		params.put("noSlackNotifications", "true");
-			    		params.put("slackNotifications", "false");
-			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project, myMainSettings)));
+			    		params.put(NO_SLACK_NOTIFICATIONS, "true");
+			    		params.put(SLACK_NOTIFICATIONS, FALSE);
+			    		params.put(PROJECT_SLACK_NOTIFICATION_AS_JSON, ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project, myMainSettings)));
 			    	} else {
-			    		params.put("noSlackNotifications", "false");
-			    		params.put("slackNotifications", "true");
+			    		params.put(NO_SLACK_NOTIFICATIONS, FALSE);
+			    		params.put(SLACK_NOTIFICATIONS, "true");
 			    		params.put("slackNotificationList", projSettings.getSlackNotificationsAsList());
 			    		params.put("slackNotificationsDisabled", !projSettings.isEnabled());
 			    		params.put("slackNotificationsEnabledAsChecked", projSettings.isEnabledAsChecked());
-			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project, myMainSettings)));
+			    		params.put(PROJECT_SLACK_NOTIFICATION_AS_JSON, ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, project, myMainSettings)));
 
 			    	}
 		    	} else {
-		    		params.put("haveProject", "false");
-		    		params.put("errorReason", "The project requested does not appear to be valid.");
+		    		params.put("haveProject", FALSE);
+		    		params.put(ERROR_REASON, "The project requested does not appear to be valid.");
 		    	}
         	} else if (request.getParameter("buildTypeId") != null){
         		SBuildType sBuildType = TeamCityIdResolver.findBuildTypeById(this.myServer.getProjectManager(), request.getParameter("buildTypeId"));
@@ -120,7 +128,7 @@ public class SlackNotificationIndexPageController extends BaseController {
 		        	if (project != null){
 		        		
 				    	SlackNotificationProjectSettings projSettings = (SlackNotificationProjectSettings)
-				    			mySettings.getSettings(project.getProjectId(), "slackNotifications");
+				    			mySettings.getSettings(project.getProjectId(), SLACK_NOTIFICATIONS);
 				    	
 				    	SUser myUser = SessionUser.getUser(request);
 				        params.put("hasPermission", myUser.isPermissionGrantedForProject(project.getProjectId(), Permission.EDIT_PROJECT));
@@ -128,7 +136,7 @@ public class SlackNotificationIndexPageController extends BaseController {
 				    	List<SlackNotificationConfig> configs = projSettings.getBuildSlackNotificationsAsList(sBuildType);
 				    	params.put("slackNotificationList", configs);
 				    	params.put("slackNotificationsDisabled", !projSettings.isEnabled());
-				    	params.put("projectId", project.getProjectId());
+				    	params.put(PROJECT_ID, project.getProjectId());
 				    	params.put("haveProject", "true");
 				    	params.put("projectName", project.getName());
 				    	params.put("projectExternalId", TeamCityIdResolver.getExternalProjectId(project));
@@ -136,18 +144,18 @@ public class SlackNotificationIndexPageController extends BaseController {
 				    	params.put("buildName", sBuildType.getName());
 				    	params.put("buildExternalId", TeamCityIdResolver.getExternalBuildId(sBuildType));
 				    	params.put("buildTypeList", project.getBuildTypes());
-			    		params.put("noSlackNotifications", configs.isEmpty());
-			    		params.put("slackNotifications", !configs.isEmpty());
+			    		params.put(NO_SLACK_NOTIFICATIONS, configs.isEmpty());
+			    		params.put(SLACK_NOTIFICATIONS, !configs.isEmpty());
 				    	
-			    		params.put("projectSlackNotificationsAsJson", ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, sBuildType, project, myMainSettings)));
+			    		params.put(PROJECT_SLACK_NOTIFICATION_AS_JSON, ProjectSlackNotificationsBeanJsonSerialiser.serialise(ProjectSlackNotificationsBean.build(projSettings, sBuildType, project, myMainSettings)));
 		        	}
         		} else {
-		    		params.put("haveProject", "false");
-		    		params.put("errorReason", "The build requested does not appear to be valid.");
+		    		params.put("haveProject", FALSE);
+		    		params.put(ERROR_REASON, "The build requested does not appear to be valid.");
         		}
 	        } else {
-	        	params.put("haveProject", "false");
-	        	params.put("errorReason", "No project specified.");
+	        	params.put("haveProject", FALSE);
+	        	params.put(ERROR_REASON, "No project specified.");
 	        }
 
 	        return new ModelAndView(myPluginDescriptor.getPluginResourcesPath() + "SlackNotification/index.jsp", params);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
This PR will reduce 120 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
Fevzi Ozgul