### PR TITLE
Fixing squid: S1132 String literals should be placed on the left when checking equality part 2

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -538,7 +538,7 @@ public class SlackNotificationImpl implements SlackNotification {
     }
 
     public void setEnabled(String enabled) {
-        if (enabled.toLowerCase().equals("true")) {
+        if ("true".equals(enabled.toLowerCase())) {
             this.enabled = true;
         } else {
             this.enabled = false;

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainConfig.java
@@ -101,11 +101,11 @@ public class SlackNotificationMainConfig implements ChangeListener {
 	public String stripProtocolFromUrl(String url){
 		String tmpURL = url;
 		if(tmpURL.length() > "https://".length() 
-			&& tmpURL.substring(0,"https://".length()).equalsIgnoreCase("https://"))
+			&& "https://".equalsIgnoreCase(tmpURL.substring(0,"https://".length())))
 		{
 				tmpURL = tmpURL.substring("https://".length());
 		} else if (tmpURL.length() > "http://".length() 
-			&& tmpURL.substring(0,"http://".length()).equalsIgnoreCase("http://"))
+			&& "http://".equalsIgnoreCase(tmpURL.substring(0,"http://".length())))
 		{
 				tmpURL = tmpURL.substring("http://".length());
 		}


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1132- “Strings literals should be placed on the left side when checking for equality”. 
This PR will remove 30 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1132
 Please let me know if you have any questions.
Fevzi Ozgul