### PR TITLE
Fixing squid:S135 Loops should not contain more than a single "break" or "continue" statement

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildState.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildState.java
@@ -122,16 +122,10 @@ public class BuildState {
 	public boolean allEnabled() {
 		boolean areAllEnbled = true;
 		for (BuildStateEnum state : states.keySet()){
-			if (state.equals(BUILD_BROKEN)){
-				if (states.get(BUILD_BROKEN).isEnabled()){
-					return false;
-				}
-				continue;
+			if ((state.equals(BUILD_BROKEN) && states.get(BUILD_BROKEN).isEnabled()) || (state.equals(BUILD_FIXED) && states.get(BUILD_FIXED).isEnabled())){
+				return false;
 			}
-			if (state.equals(BUILD_FIXED)){
-				if (states.get(BUILD_FIXED).isEnabled()){
-					return false;
-				}
+			if (state.equals(BUILD_BROKEN) || state.equals(BUILD_FIXED)) {
 				continue;
 			}
 			areAllEnbled = areAllEnbled && states.get(state).isEnabled();  


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S135 - “Loops should not contain more than a single "break" or "continue" statement”. 
This PR will remove 40 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S135
 Please let me know if you have any questions.
Fevzi Ozgul