### PR TITLE
Fixing squid: S135 Loops should not contain more than a single "break  " or "continue" statement part 2

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildState.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/BuildState.java
@@ -142,27 +142,17 @@ public class BuildState {
 	public boolean noneEnabled() {
 		int enabled = 0;
 		for (BuildStateEnum state : states.keySet()){
-			if (state.equals(BUILD_BROKEN)){
-				continue;
-			}
-			if (state.equals(BUILD_FIXED)){
-				continue;
-			}
-			if (state.equals(BUILD_SUCCESSFUL)){
-				continue;
-			}
-			if (state.equals(BUILD_FAILED)){
-				continue;
-			}
-			
 			if (state.equals(BUILD_FINISHED)){
 				if (finishEnabled()){
 					enabled++;
 				}
+			}
+			if (state.equals(BUILD_FINISHED) || state.equals(BUILD_BROKEN) || state.equals(BUILD_FIXED) || state.equals(BUILD_SUCCESSFUL) || state.equals(BUILD_FAILED)){
 				continue;
 			}
-			if (states.get(state).isEnabled())  
+			if (states.get(state).isEnabled()){
 				enabled++;
+			}
 		}
 		return enabled == 0;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S135 - “Loops should not contain more than a single "break" or "continue" statement”. 
This PR will remove 80 min of TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S135
Please let me know if you have any questions.
Fevzi Ozgul