### PR TITLE
Fixing squid: S1186 methods should not be empty 

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
@@ -274,7 +274,7 @@ public class SlackNotificationListener extends BuildServerAdapter {
 	}
 	
 	public void responsibleRemoved(SProject project, TestNameResponsibilityEntry entry){
-		
+		throw new UnsupportedOperationException("This method is not implemented yet!");
 	}
 	
     

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificator.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificator.java
@@ -58,7 +58,7 @@ public class SlackNotificator implements Notificator {
     }
 
     public void register(){
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
@@ -99,11 +99,12 @@ public class SlackNotificator implements Notificator {
 
     @Override
     public void notifyBuildFailedToStart(SRunningBuild sRunningBuild, Set<SUser> set) {
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyLabelingFailed(Build build, VcsRoot vcsRoot, Throwable throwable, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
@@ -120,67 +121,67 @@ public class SlackNotificator implements Notificator {
 
     @Override
     public void notifyBuildProbablyHanging(SRunningBuild sRunningBuild, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyResponsibleChanged(SBuildType sBuildType, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyResponsibleAssigned(SBuildType sBuildType, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyResponsibleChanged(TestNameResponsibilityEntry testNameResponsibilityEntry, TestNameResponsibilityEntry testNameResponsibilityEntry1, SProject sProject, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyResponsibleAssigned(TestNameResponsibilityEntry testNameResponsibilityEntry, TestNameResponsibilityEntry testNameResponsibilityEntry1, SProject sProject, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyResponsibleChanged(Collection<TestName> collection, ResponsibilityEntry responsibilityEntry, SProject sProject, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyResponsibleAssigned(Collection<TestName> collection, ResponsibilityEntry responsibilityEntry, SProject sProject, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyBuildProblemResponsibleAssigned(Collection<BuildProblemInfo> collection, ResponsibilityEntry responsibilityEntry, SProject sProject, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyBuildProblemResponsibleChanged(Collection<BuildProblemInfo> collection, ResponsibilityEntry responsibilityEntry, SProject sProject, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyTestsMuted(Collection<STest> collection, MuteInfo muteInfo, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyTestsUnmuted(Collection<STest> collection, MuteInfo muteInfo, SUser sUser, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyBuildProblemsMuted(Collection<BuildProblemInfo> collection, MuteInfo muteInfo, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @Override
     public void notifyBuildProblemsUnmuted(Collection<BuildProblemInfo> collection, MuteInfo muteInfo, SUser sUser, Set<SUser> set) {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     @NotNull

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
@@ -77,7 +77,6 @@ public class SlackNotificationPayloadContent {
     private ArrayList<String> failedTestNames = new ArrayList<String>();
 
     public SlackNotificationPayloadContent(){
-        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
 
     /**

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
@@ -77,8 +77,8 @@ public class SlackNotificationPayloadContent {
     private ArrayList<String> failedTestNames = new ArrayList<String>();
 
     public SlackNotificationPayloadContent(){
-
-        }
+        throw new UnsupportedOperationException("This method is not implemented yet!");
+    }
 
     /**
 		 * Constructor: Only called by RepsonsibilityChanged.

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
@@ -62,7 +62,7 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
      * in memory. 
      */
     {
-
+        throw new UnsupportedOperationException("This method is not implemented yet!");
     }
     
     public String getProxy(){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1186 - “methods should not be empty”. 
This PR will remove 95min off TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1186
 Please let me know if you have any questions.
Fevzi Ozgul