### PR TITLE
Fixing squid: S1132 Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
@@ -113,7 +113,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 			    		if ((projSettings != null) && (myProject != null)
 			    				&& (myUser.isPermissionGrantedForProject(myProject.getProjectId(), Permission.EDIT_PROJECT))){
 			    			if ((request.getParameter(SUBMIT_ACTION) != null ) 
-			    				&& (request.getParameter(SUBMIT_ACTION).equals("removeSlackNotification"))
+			    				&& ("removeSlackNotification".equals(request.getParameter(SUBMIT_ACTION)))
 			    				&& (request.getParameter("removedSlackNotificationId") != null)){
 			    					projSettings.deleteSlackNotification(request.getParameter("removedSlackNotificationId"), myProject.getProjectId());
 			    					if(projSettings.updateSuccessful()){
@@ -124,7 +124,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 			    					}
 			    					
 			    			} else if ((request.getParameter(SUBMIT_ACTION) != null ) 
-				    				&& (request.getParameter(SUBMIT_ACTION).equals("updateSlackNotification"))){
+				    				&& ("updateSlackNotification".equals(request.getParameter(SUBMIT_ACTION)))){
 			    				if((request.getParameter(CHANNEL) != null )
 				    				&& (request.getParameter(CHANNEL).length() > 0 )){
 			    					
@@ -249,7 +249,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 	    		}
 	    	}
 
-	    	if (request.getMethod().equalsIgnoreCase("get")
+	    	if ("get".equalsIgnoreCase(request.getMethod())
 	        		&& request.getParameter(PROJECT_ID) != null 
 	        		&& request.getParameter(PROJECT_ID).startsWith("project")){
 	        	


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1132- “Strings literals should be placed on the left side when checking for equality”. 
This PR will remove 30 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1132
 Please let me know if you have any questions.
Fevzi Ozgul