### PR TITLE
Fixing squid: S1166 Exception handlers should preserve the original exception part 2

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/TestListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/TestListener.java
@@ -8,9 +8,13 @@ import jetbrains.buildServer.tests.TestName;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class TestListener extends BuildServerAdapter {
-	
+
+	private static final Logger LOGGER = Logger.getLogger(TestListener.class.getName());
+
 	private SBuildServer myBuildServer;
 
 	public TestListener(SBuildServer sBuildServer, ProjectSettingsManager settings) {
@@ -60,10 +64,14 @@ public class TestListener extends BuildServerAdapter {
 		String newUser = "Nobody";
 		try {
 			oldUser = oldValue.getResponsibleUser().getDescriptiveName();
-		} catch (Exception e) {}
+		} catch (Exception e) {
+			LOGGER.log(Level.INFO,e.getMessage(),e);
+		}
 		try {
 			newUser = newValue.getResponsibleUser().getDescriptiveName();
-		} catch (Exception e) {}
+		} catch (Exception e) {
+			LOGGER.log(Level.INFO,e.getMessage(),e);
+		}
 		logit("Build " + bt.getFullName() 
 				+ " has changed responsibility from " 
 				+ oldUser + " to " + newUser);

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/SlackNotificationPayloadManager.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/SlackNotificationPayloadManager.java
@@ -11,10 +11,13 @@ import slacknotifications.teamcity.Loggers;
 import slacknotifications.teamcity.payload.content.SlackNotificationPayloadContent;
 
 import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class SlackNotificationPayloadManager {
 
     private static final String NOBODY = "nobody";
+    private static final Logger LOGGER = Logger.getLogger(SlackNotificationPayloadManager.class.getName());
 	SBuildServer server;
 
     public SlackNotificationPayloadManager(SBuildServer server){
@@ -55,10 +58,14 @@ public class SlackNotificationPayloadManager {
         String newUser = NOBODY;
         try {
             oldUser = responsibilityInfoOld.getResponsibleUser().getDescriptiveName();
-        } catch (Exception e) {}
+        } catch (Exception e) {
+            LOGGER.log(Level.INFO,e.getMessage(),e);
+        }
         try {
             newUser = responsibilityInfoNew.getResponsibleUser().getDescriptiveName();
-        } catch (Exception e) {}
+        } catch (Exception e) {
+            LOGGER.log(Level.INFO,e.getMessage(),e);
+        }
 
         content.setText(buildType.getFullName() 
                         + " changed responsibility from "


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1166- “ Exception handlers should preserve the original exception”. 
This PR will remove 40  min of TD.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1166
Please let me know if you have any questions.
Fevzi Ozgul