### PR TITLE
Fixing squid. S1161 "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
@@ -272,7 +272,8 @@ public class SlackNotificationListener extends BuildServerAdapter {
 						//Loggers.ACTIVITIES.debug("SlackNotificationListener :: " + myManager.getFormat(whcw.whc.getPayloadFormat()).getFormatDescription());
      	}
 	}
-	
+
+	@Override
 	public void responsibleRemoved(SProject project, TestNameResponsibilityEntry entry){
 		
 	}

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationMainSettings.java
@@ -38,6 +38,7 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
 	}
 	
     @SuppressWarnings("unchecked")
+    @Override
     public void readFrom(Element rootElement)
     /* Is passed an Element by TC, and is expected to persist it to the settings object.
      * Old settings should be overwritten.
@@ -57,6 +58,7 @@ public class SlackNotificationMainSettings implements MainConfigProcessor {
         tempConfig.save();
     }
 
+    @Override
     public void writeTo(Element parentElement)
     /* Is passed an (probably empty) Element by TC, which is expected to be populated from the settings
      * in memory. 

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -28,6 +28,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
 	}
 
     @SuppressWarnings("unchecked")
+	@Override
 	public void readFrom(Element rootElement)
     /* Is passed an Element by TC, and is expected to load it into the in memory settings object.
      * Old settings should be overwritten.
@@ -57,6 +58,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
     	}
     }
 
+	@Override
     public void writeTo(Element parentElement)
     /* Is passed an (probably empty) Element by TC, which is expected to be populated from the settings
      * in memory. 
@@ -170,7 +172,8 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
     public Boolean updateSuccessful(){
     	return this.updateSuccess;
     }
-    
+
+	@Override
 	public void dispose() {
 		Loggers.SERVER.debug(NAME + ":dispose() called");
 	}

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettingsFactory.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettingsFactory.java
@@ -12,6 +12,7 @@ public class SlackNotificationProjectSettingsFactory implements ProjectSettingsF
 		projectSettingsManager.registerSettingsFactory("slackNotifications", this);
 	}
 
+	@Override
 	public SlackNotificationProjectSettings createProjectSettings(String projectId) {
 		Loggers.SERVER.info("SlackNotificationProjectSettingsFactory: re-reading settings for " + projectId);
 		SlackNotificationProjectSettings whs = new SlackNotificationProjectSettings();

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
@@ -96,6 +96,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 	    }
 
 	    @Nullable
+		@Override
 	    protected ModelAndView doHandle(HttpServletRequest request, HttpServletResponse response) throws Exception {
 	    	
 	        HashMap<String,Object> params = new HashMap<String,Object>();

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxSettingsListPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxSettingsListPageController.java
@@ -49,6 +49,7 @@ public class SlackNotificationAjaxSettingsListPageController extends BaseControl
 	      myWebManager.registerController("/slacknotifications/settingsList.html", this);
 	    }
 
+		@Override
 	    @Nullable
 	    protected ModelAndView doHandle(HttpServletRequest request, HttpServletResponse response) throws Exception {
 	    	

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationBuildTabExtension.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationBuildTabExtension.java
@@ -38,6 +38,7 @@ public class SlackNotificationBuildTabExtension extends BuildTypeTab {
 		myPluginPath = pluginDescriptor.getPluginResourcesPath();
 	}
 
+	@Override
 	public boolean isAvailable(@NotNull HttpServletRequest request) {
 		return true;
 	}

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationIndexPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationIndexPageController.java
@@ -59,6 +59,7 @@ public class SlackNotificationIndexPageController extends BaseController {
 	      myWebManager.registerController("/slacknotifications/index.html", this);
 	    }
 
+		@Override
 	    @Nullable
 	    protected ModelAndView doHandle(HttpServletRequest request, HttpServletResponse response) throws Exception {
 	    	

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationProjectTabExtension.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationProjectTabExtension.java
@@ -32,6 +32,7 @@ public class SlackNotificationProjectTabExtension extends ProjectTab {
 		myPluginPath = pluginDescriptor.getPluginResourcesPath();
 	}
 
+	@Override
 	public boolean isAvailable(@NotNull HttpServletRequest request) {
 		return true;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1161- “  "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. 
This PR will remove 70 min of TD.
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1161
 Please let me know if you have any questions.
Fevzi Ozgul