### PR TITLE
Set API token in SlackNotificationConfig#getAsElement, fixes #86

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -229,6 +229,9 @@ public class SlackNotificationConfig {
 	public Element getAsElement(){
 		Element el = new Element("slackNotification");
 		el.setAttribute(CHANNEL, this.getChannel());
+		if(StringUtil.isNotEmpty(this.getToken())) {
+			el.setAttribute(TOKEN, this.getToken());
+		}
 
         if(StringUtil.isNotEmpty(this.getTeamName())) {
             el.setAttribute(TEAM_NAME, this.getTeamName());

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/settings/SlackNotificationConfigTest.java
@@ -60,6 +60,11 @@ public class SlackNotificationConfigTest {
 	}
 
 	@Test
+	public void testGetToken() {
+		assertTrue(slacknotificationAllEnabled.getToken().equals("hook.slack.com"));
+	}
+
+	@Test
 	public void testGetUrl() {
 		assertTrue(slacknotificationAllEnabled.getChannel().equals("http://localhost/test"));
 	}

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-but-respchange-states-enabled.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-but-respchange-states-enabled.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <slackNotifications enabled="true">
-    <slackNotification channel="http://localhost/test" enabled="true" format="nvpairs">
+    <slackNotification token="hook.slack.com" channel="http://localhost/test" enabled="true" format="nvpairs">
       <states>
         <state type="buildStarted" enabled="true" />
         <state type="beforeBuildFinish" enabled="true" />

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-disabled.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-disabled.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <slackNotifications enabled="true">
-    <slackNotification channel="http://localhost/test" enabled="true" format="nvpairs">
+    <slackNotification token="hook.slack.com" channel="http://localhost/test" enabled="true" format="nvpairs">
       <states>
         <state type="buildStarted" enabled="false" />
         <state type="beforeBuildFinish" enabled="false" />

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-branch-and-custom-templates.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-branch-and-custom-templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <slackNotifications enabled="true">
-    <slackNotification channel="http://localhost/test" enabled="true" format="nvpairs">
+    <slackNotification token="hook.slack.com" channel="http://localhost/test" enabled="true" format="nvpairs">
       <states>
         <state type="buildStarted" enabled="true" />
         <state type="beforeBuildFinish" enabled="true" />

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-custom-templates.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-custom-templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <slackNotifications enabled="true">
-    <slackNotification channel="http://localhost/test" enabled="true" format="nvpairs">
+    <slackNotification token="hook.slack.com" channel="http://localhost/test" enabled="true" format="nvpairs">
       <states>
         <state type="buildStarted" enabled="true" />
         <state type="beforeBuildFinish" enabled="true" />

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-specific-builds.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled-with-specific-builds.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <slackNotifications enabled="true">
-    <slackNotification channel="http://localhost/test" enabled="true" format="nvpairs">
+    <slackNotification token="hook.slack.com" channel="http://localhost/test" enabled="true" format="nvpairs">
       <states>
         <state type="buildStarted" enabled="true" />
         <state type="beforeBuildFinish" enabled="true" />

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-test-all-states-enabled.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <slackNotifications enabled="true">
-    <slackNotification channel="http://localhost/test" enabled="true" format="nvpairs">
+    <slackNotification token="hook.slack.com" channel="http://localhost/test" enabled="true" format="nvpairs">
       <states>
         <state type="buildStarted" enabled="true" />
         <state type="beforeBuildFinish" enabled="true" />

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-test-custom-content.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-test-custom-content.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <slackNotifications enabled="true">
-    <slackNotification channel="http://localhost/test" enabled="true" format="nvpairs">
+    <slackNotification token="hook.slack.com" channel="http://localhost/test" enabled="true" format="nvpairs">
       <states>
         <state type="buildStarted" enabled="true" />
       </states>

--- a/tcslackbuildnotifier-core/src/test/resources/project-settings-test-slacknotifications-disabled.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/project-settings-test-slacknotifications-disabled.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <slackNotifications enabled="true">
-    <slackNotification channel="http://localhost/test" enabled="false" format="nvpairs">
+    <slackNotification token="hook.slack.com" channel="http://localhost/test" enabled="false" format="nvpairs">
       <states>
         <state type="buildStarted" enabled="false" />
         <state type="beforeBuildFinish" enabled="false" />

--- a/tcslackbuildnotifier-core/src/test/resources/testdoc1.xml
+++ b/tcslackbuildnotifier-core/src/test/resources/testdoc1.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <slackNotifications enabled="false">
-    <slackNotification enabled="true" channel="http://something" statemask="255">
+    <slackNotification enabled="true" token="hook.slack.com" channel="http://something" statemask="255">
       <parameters>
 	    <param name="foo" value="bar" />
       </parameters>
     </slackNotification>
-    <slackNotification enabled="true" channel="http://localhost.local.network/slacknotifications/test/test">
+    <slackNotification enabled="true" token="hook.slack.com" channel="http://localhost.local.network/slacknotifications/test/test">
       <parameters>
 	    <param name="fromTeamCity" value="%system.test.1%" />
       </parameters>
     </slackNotification>
-    <slackNotification enabled="false" channel="http://localhost.local.network/slacknotifications/test/teamcity" />
+    <slackNotification enabled="false" token="hook.slack.com" channel="http://localhost.local.network/slacknotifications/test/teamcity" />
   </slackNotifications>
 </settings>


### PR DESCRIPTION
For backwards-compatibility, allows configs to be read/written without a token set. Includes test updates as well.

This reverts commit 4b8cb6284b5bc1d9a784601af64499e5b3b9c6b1.