### PR TITLE
Update slackUser format to enable mention in slack

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -330,7 +330,7 @@ public class SlackNotificationImpl implements SlackNotification {
 
         for(Commit commit : commits){
             if(commit.hasSlackUsername()){
-                slackUsers.add("@" + commit.getSlackUserName());
+                slackUsers.add("<@" + commit.getSlackUserName() + ">");
             }
         }
         HashSet<String> tempHash = new HashSet<String>(slackUsers);


### PR DESCRIPTION
To enable slack notification for the commit user, the format of the user should be like <@username> instead of just @username