### PR TITLE
Set `as_user` to false

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -164,7 +164,7 @@ public class SlackNotificationImpl implements SlackNotification {
             if (this.teamName == null) {
                 this.teamName = "";
             }
-            String url = String.format("https://slack.com/api/chat.postMessage?token=%s&link_names=1&username=%s&icon_url=%s&channel=%s&text=%s&pretty=1",
+            String url = String.format("https://slack.com/api/chat.postMessage?token=%s&link_names=1&as_user=0&username=%s&icon_url=%s&channel=%s&text=%s&pretty=1",
                     this.token,
                     this.botName == null ? "" : URLEncoder.encode(this.botName, UTF8),
                     this.iconUrl == null ? "" : URLEncoder.encode(this.iconUrl, UTF8),


### PR DESCRIPTION
So `username` & `icon_url` are not ignored

According to [Slack API docs](https://api.slack.com/methods/chat.postMessage):
 * `icon_url` : URL to an image to use as the icon for this message. Must be used in conjunction with `as_user` set to `false`, ___otherwise ignored___
 * `username`: Set your bot's user name. Must be used in conjunction with `as_user` set to `false`, ___otherwise ignored___

