### PR TITLE
Mention who triggered

### DIFF
--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotification.java
@@ -114,4 +114,6 @@ public interface SlackNotification {
 	public abstract void setMentionHereEnabled(boolean mentionHereEnabled);
 
     public abstract void setShowFailureReason(boolean showFailureReason);
+
+	public abstract void setMentionWhoTriggeredEnabled(boolean mentionWhoTriggeredEnabled);
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -330,8 +330,8 @@ public class SlackNotificationImpl implements SlackNotification {
 
 
         for(Commit commit : commits){
-            if(commit.hasSlackUsername()){
-                slackUsers.add("<@" + commit.getSlackUserName() + ">");
+            if(commit.hasSlackUserId()){
+                slackUsers.add("<!" + commit.getSlackUserId() + ">");
             }
         }
         HashSet<String> tempHash = new HashSet<String>(slackUsers);

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/SlackNotificationImpl.java
@@ -70,8 +70,9 @@ public class SlackNotificationImpl implements SlackNotification {
     private boolean mentionChannelEnabled;
     private boolean mentionSlackUserEnabled;
     private boolean mentionHereEnabled;
+    private boolean mentionWhoTriggeredEnabled;
     private boolean showFailureReason;
-	
+
 /*	This is a bit mask of states that should trigger a SlackNotification.
  *  All ones (11111111) means that all states will trigger the slacknotifications
  *  We'll set that as the default, and then override if we get a more specific bit mask. */
@@ -354,12 +355,16 @@ public class SlackNotificationImpl implements SlackNotification {
         }
 
         // Mention the channel and/or the Slack Username of any committers if known
-        if(payload.getIsFirstFailedBuild()
+        boolean needMentionForFirstFailure = payload.getIsFirstFailedBuild()
                 && (mentionChannelEnabled
-                    || mentionHereEnabled
-                    ||(mentionSlackUserEnabled
-                        && !slackUsers.isEmpty()))){
-            String mentionContent = ":arrow_up: \"" + this.payload.getBuildName() + "\" Failed ";
+                || mentionHereEnabled
+                || (mentionSlackUserEnabled
+                && !slackUsers.isEmpty()));
+
+        String mentionContent = ":arrow_up: ";
+        if(needMentionForFirstFailure){
+            mentionContent += "\"" + this.payload.getBuildName() + "\" Failed ";
+
             if(mentionChannelEnabled){
                 mentionContent += "<!channel> ";
             }
@@ -369,6 +374,14 @@ public class SlackNotificationImpl implements SlackNotification {
             if (mentionHereEnabled) {
                 mentionContent += "<!here>";
             }
+        }
+
+        boolean needMentionForTheOneWhoTriggered = mentionWhoTriggeredEnabled && payload.getTriggeredBySlackUserId() != null;
+        if (needMentionForTheOneWhoTriggered) {
+            mentionContent += "<@" + payload.getTriggeredBySlackUserId() + ">";
+        }
+
+        if (needMentionForFirstFailure || needMentionForTheOneWhoTriggered) {
             attachment.addField("", mentionContent, true);
         }
 
@@ -668,6 +681,15 @@ public class SlackNotificationImpl implements SlackNotification {
     @Override
     public void setShowFailureReason(boolean showFailureReason) {
         this.showFailureReason = showFailureReason;
+    }
+
+    public boolean isMentionWhoTriggeredEnabled() {
+        return mentionWhoTriggeredEnabled;
+    }
+
+    @Override
+    public void setMentionWhoTriggeredEnabled(boolean mentionWhoTriggeredEnabled) {
+        this.mentionWhoTriggeredEnabled = mentionWhoTriggeredEnabled;
     }
 
     public boolean getIsApiToken() {

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificationListener.java
@@ -81,6 +81,7 @@ public class SlackNotificationListener extends BuildServerAdapter {
         slackNotification.setMaxCommitsToDisplay(myMainSettings.getMaxCommitsToDisplay());
         slackNotification.setMentionChannelEnabled(slackNotificationConfig.getMentionChannelEnabled());
 		slackNotification.setMentionSlackUserEnabled(slackNotificationConfig.getMentionSlackUserEnabled());
+		slackNotification.setMentionWhoTriggeredEnabled(slackNotificationConfig.isMentionWhoTriggeredEnabled());
 		slackNotification.setMentionHereEnabled(slackNotificationConfig.getMentionHereEnabled());
         slackNotification.setShowElapsedBuildTime(myMainSettings.getShowElapsedBuildTime());
         if(slackNotificationConfig.getContent() != null && slackNotificationConfig.getContent().isEnabled()) {

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificator.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificator.java
@@ -14,15 +14,12 @@ import jetbrains.buildServer.users.PropertyKey;
 import jetbrains.buildServer.users.SUser;
 import jetbrains.buildServer.util.StringUtil;
 import jetbrains.buildServer.vcs.VcsRoot;
-import org.apache.http.HttpStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import slacknotifications.SlackNotification;
 import slacknotifications.teamcity.payload.SlackNotificationPayloadManager;
 import slacknotifications.teamcity.settings.SlackNotificationMainSettings;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -37,22 +34,19 @@ public class SlackNotificator implements Notificator {
     private ArrayList<UserPropertyInfo> userProps;
     private NotificationUtility notificationUtility;
 
-    private static final String SLACK_USERNAME_KEY = "tcSlackNotifier.userName";
     private static final String SLACK_USERID_KEY = "tcSlackNotifier.userId";
     private static final String TYPE = "tcSlackBuildNotifier";
 
-    public static final PropertyKey USERNAME_KEY = new NotificatorPropertyKey(TYPE, SLACK_USERNAME_KEY);
     public static final PropertyKey USERID_KEY = new NotificatorPropertyKey(TYPE, SLACK_USERID_KEY);
 
     public SlackNotificator(NotificatorRegistry notificatorRegistry,
                             SBuildServer sBuildServer,
                             SlackNotificationMainSettings configSettings,
                             SlackNotificationFactory factory,
-                            SlackNotificationPayloadManager manager){
+                            SlackNotificationPayloadManager manager) {
         Loggers.ACTIVITIES.debug("Registering SlackNotificator...");
 
         userProps = new ArrayList<UserPropertyInfo>();
-        userProps.add(new UserPropertyInfo(SLACK_USERNAME_KEY, "Slack Username"));
         userProps.add(new UserPropertyInfo(SLACK_USERID_KEY, "Slack User Id"));
         notificatorRegistry.register(this, userProps);
         mainConfig = configSettings;
@@ -62,14 +56,14 @@ public class SlackNotificator implements Notificator {
         notificationUtility = new NotificationUtility();
     }
 
-    public void register(){
+    public void register() {
 
     }
 
     @Override
     public void notifyBuildStarted(SRunningBuild sRunningBuild, Set<SUser> set) {
-        for(SUser sUser : set){
-            if(!userHasSlackNameConfigured(sUser)){
+        for (SUser sUser : set) {
+            if (!userHasSlackIdConfigured(sUser)) {
                 continue;
             }
             SlackNotification slackNotification = createNotification(sUser);
@@ -80,8 +74,8 @@ public class SlackNotificator implements Notificator {
 
     @Override
     public void notifyBuildSuccessful(SRunningBuild sRunningBuild, Set<SUser> set) {
-        for(SUser sUser : set){
-            if(!userHasSlackNameConfigured(sUser)){
+        for (SUser sUser : set) {
+            if (!userHasSlackIdConfigured(sUser)) {
                 continue;
             }
             SlackNotification slackNotification = createNotification(sUser);
@@ -92,8 +86,8 @@ public class SlackNotificator implements Notificator {
 
     @Override
     public void notifyBuildFailed(SRunningBuild sRunningBuild, Set<SUser> set) {
-        for(SUser sUser : set){
-            if(!userHasSlackNameConfigured(sUser)){
+        for (SUser sUser : set) {
+            if (!userHasSlackIdConfigured(sUser)) {
                 continue;
             }
             SlackNotification slackNotification = createNotification(sUser);
@@ -113,8 +107,8 @@ public class SlackNotificator implements Notificator {
 
     @Override
     public void notifyBuildFailing(SRunningBuild sRunningBuild, Set<SUser> set) {
-        for(SUser sUser : set){
-            if(!userHasSlackNameConfigured(sUser)){
+        for (SUser sUser : set) {
+            if (!userHasSlackIdConfigured(sUser)) {
                 continue;
             }
             SlackNotification slackNotification = createNotification(sUser);
@@ -201,13 +195,13 @@ public class SlackNotificator implements Notificator {
     }
 
 
-    private boolean userHasSlackNameConfigured(SUser sUser){
-        String userName = sUser.getPropertyValue(USERNAME_KEY);
+    private boolean userHasSlackIdConfigured(SUser sUser) {
+        String userName = sUser.getPropertyValue(USERID_KEY);
 
-        return userName != null && StringUtil.isNotEmpty(userName);
+        return StringUtil.isNotEmpty(userName);
     }
 
-    private SlackNotification createNotification(SUser sUser){
+    private SlackNotification createNotification(SUser sUser) {
         SlackNotification notification = notificationFactory.getSlackNotification();
         String userId = sUser.getPropertyValue(USERID_KEY);
         notification.setChannel(userId);
@@ -228,8 +222,7 @@ public class SlackNotificator implements Notificator {
     }
 
     @Nullable
-    private SFinishedBuild getPreviousNonPersonalBuild(SRunningBuild paramSRunningBuild)
-    {
+    private SFinishedBuild getPreviousNonPersonalBuild(SRunningBuild paramSRunningBuild) {
         List<SFinishedBuild> localList = buildServer.getHistory().getEntriesBefore(paramSRunningBuild, false);
 
         for (SFinishedBuild localSFinishedBuild : localList)

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificator.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/SlackNotificator.java
@@ -38,9 +38,11 @@ public class SlackNotificator implements Notificator {
     private NotificationUtility notificationUtility;
 
     private static final String SLACK_USERNAME_KEY = "tcSlackNotifier.userName";
+    private static final String SLACK_USERID_KEY = "tcSlackNotifier.userId";
     private static final String TYPE = "tcSlackBuildNotifier";
 
     public static final PropertyKey USERNAME_KEY = new NotificatorPropertyKey(TYPE, SLACK_USERNAME_KEY);
+    public static final PropertyKey USERID_KEY = new NotificatorPropertyKey(TYPE, SLACK_USERID_KEY);
 
     public SlackNotificator(NotificatorRegistry notificatorRegistry,
                             SBuildServer sBuildServer,
@@ -51,6 +53,7 @@ public class SlackNotificator implements Notificator {
 
         userProps = new ArrayList<UserPropertyInfo>();
         userProps.add(new UserPropertyInfo(SLACK_USERNAME_KEY, "Slack Username"));
+        userProps.add(new UserPropertyInfo(SLACK_USERID_KEY, "Slack User Id"));
         notificatorRegistry.register(this, userProps);
         mainConfig = configSettings;
         notificationFactory = factory;
@@ -206,12 +209,8 @@ public class SlackNotificator implements Notificator {
 
     private SlackNotification createNotification(SUser sUser){
         SlackNotification notification = notificationFactory.getSlackNotification();
-        String userName = sUser.getPropertyValue(USERNAME_KEY);
-        if(userName.substring(0,1) == "@"){
-            userName = userName.substring(1);
-        }
-        notification.setChannel("@" + userName);
-
+        String userId = sUser.getPropertyValue(USERID_KEY);
+        notification.setChannel(userId);
         notification.setTeamName(mainConfig.getTeamName());
         notification.setToken(mainConfig.getToken());
         notification.setIconUrl(mainConfig.getIconUrl());

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/Commit.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/Commit.java
@@ -7,21 +7,21 @@ import jetbrains.buildServer.util.StringUtil;
  */
 public class Commit {
 
-    public Commit(String revision, String description, String userName, String slackUserName) {
+    public Commit(String revision, String description, String userName, String slackUserId) {
         this.description = description;
         this.userName = userName;
         this.revision = revision;
 
-        if(slackUserName != null && slackUserName.startsWith("@")){
-            slackUserName = slackUserName.substring(1);
+        if(slackUserId != null && slackUserId.startsWith("@")){
+            slackUserId = slackUserId.substring(1);
         }
-        this.slackUserName = slackUserName;
+        this.slackUserId = slackUserId;
     }
 
     private String description;
     private String userName;
     private String revision;
-    private String slackUserName;
+    private String slackUserId;
 
     public String getRevision() {
         return revision;
@@ -47,18 +47,18 @@ public class Commit {
         this.userName = userName;
     }
 
-    public String getSlackUserName() {
-        return slackUserName;
+    public String getSlackUserId() {
+        return slackUserId;
     }
 
-    public void setSlackUserName(String slackUserName) {
-        if(slackUserName != null && slackUserName.startsWith("@")){
-            slackUserName = slackUserName.substring(1);
+    public void setSlackUserId(String slackUserId) {
+        if(slackUserId != null && slackUserId.startsWith("@")){
+            slackUserId = slackUserId.substring(1);
         }
-        this.slackUserName = slackUserName;
+        this.slackUserId = slackUserId;
     }
 
-    public boolean hasSlackUsername(){
-        return slackUserName != null && StringUtil.isNotEmpty(slackUserName);
+    public boolean hasSlackUserId(){
+        return StringUtil.isNotEmpty(slackUserId);
     }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/PayloadContentCommits.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/PayloadContentCommits.java
@@ -25,13 +25,13 @@ public class PayloadContentCommits {
 
         for (SVcsModification change : changes) {
             Collection<SUser> committers = change.getCommitters();
-            String slackUserName = null;
-            if (committers != null && !committers.isEmpty()) {
+            String slackUserId = null;
+            if (!committers.isEmpty()) {
                 SUser committer = committers.iterator().next();
-                slackUserName = committer.getPropertyValue(SlackNotificator.USERNAME_KEY);
-                Loggers.ACTIVITIES.debug("Resolved committer " + change.getUserName() + " to Slack User " + slackUserName);
+                slackUserId = committer.getPropertyValue(SlackNotificator.USERID_KEY);
+                Loggers.ACTIVITIES.debug("Resolved committer " + change.getUserName() + " to Slack User " + slackUserId);
             }
-            commits.add(new Commit(change.getVersion(), change.getDescription(), change.getUserName(), slackUserName));
+            commits.add(new Commit(change.getVersion(), change.getDescription(), change.getUserName(), slackUserId));
         }
     }
 

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/payload/content/SlackNotificationPayloadContent.java
@@ -5,6 +5,7 @@ import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.tests.TestInfo;
 import slacknotifications.teamcity.BuildStateEnum;
 import slacknotifications.teamcity.Loggers;
+import slacknotifications.teamcity.SlackNotificator;
 import slacknotifications.teamcity.TeamCityIdResolver;
 
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ public class SlackNotificationPayloadContent {
     String agentOs;
     String agentHostname;
     String triggeredBy;
+    String triggeredBySlackUserId;
     String comment;
     String message;
     String text;
@@ -173,6 +175,9 @@ public class SlackNotificationPayloadContent {
         setBuildResult(sRunningBuild, previousBuild, buildState);
         setBuildFullName(sRunningBuild.getBuildType().getFullName());
         setBuildName(sRunningBuild.getBuildType().getName());
+        if (sRunningBuild.getTriggeredBy().getUser() != null) {
+            setTriggeredBySlackUserId(sRunningBuild.getTriggeredBy().getUser().getPropertyValue(SlackNotificator.USERID_KEY));
+        }
         setTriggeredBy(sRunningBuild.getTriggeredBy().getAsString());
         setBuildId(Long.toString(sRunningBuild.getBuildId()));
         setBuildTypeId(TeamCityIdResolver.getBuildTypeId(sRunningBuild.getBuildType()));
@@ -418,5 +423,13 @@ public class SlackNotificationPayloadContent {
 
     public ArrayList<String> getFailedTestNames() {
         return failedTestNames;
+    }
+
+    public String getTriggeredBySlackUserId() {
+        return triggeredBySlackUserId;
+    }
+
+    public void setTriggeredBySlackUserId(String triggeredBySlackUserId) {
+        this.triggeredBySlackUserId = triggeredBySlackUserId;
     }
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationConfig.java
@@ -23,6 +23,7 @@ public class SlackNotificationConfig {
 	private static final String CHANNEL_ENABLED_MESSAGE = "mention-channel-enabled";
 	private static final String SLACK_USER_ENABLED_MESSAGE = "mention-slack-user-enabled";
 	private static final String HERE_ENABLED_MESSAGE = "mention-here-enabled";
+	private static final String WHO_TRIGGERED_ENABLED_MESSAGE = "mention-who-triggered-enabled";
 	private static final String STATES = "states";
 	private static final String BUILD_TYPES = "build-types";
 	private static final String ENABLED_FOR_ALL = "enabled-for-all";
@@ -52,6 +53,7 @@ public class SlackNotificationConfig {
     private boolean mentionChannelEnabled;
 	private boolean mentionSlackUserEnabled;
 	private boolean mentionHereEnabled;
+	private boolean mentionWhoTriggeredEnabled;
     private boolean customContent;
     private SlackNotificationContentConfig content;
 
@@ -97,6 +99,10 @@ public class SlackNotificationConfig {
 
 		if (e.getAttribute(HERE_ENABLED_MESSAGE) != null){
 			this.setMentionHereEnabled(Boolean.parseBoolean(e.getAttributeValue("mention-here-enabled")));
+		}
+
+		if (e.getAttribute(WHO_TRIGGERED_ENABLED_MESSAGE) != null){
+			this.setMentionWhoTriggeredEnabled(Boolean.parseBoolean(e.getAttributeValue(WHO_TRIGGERED_ENABLED_MESSAGE)));
 		}
 		
 		if(e.getChild(STATES) != null){
@@ -216,7 +222,8 @@ public class SlackNotificationConfig {
 								   Set<String> enabledBuildTypes,
 								   boolean mentionChannelEnabled,
 								   boolean mentionSlackUserEnabled,
-								   boolean mentionHereEnabled) {
+								   boolean mentionHereEnabled,
+								   boolean mentionWhoTriggeredEnabled) {
         this.content = new SlackNotificationContentConfig();
         int Min = 1000000, Max = 1000000000;
         Integer Rand = Min + (int) (Math.random() * ((Max - Min) + 1));
@@ -232,6 +239,7 @@ public class SlackNotificationConfig {
         this.setMentionChannelEnabled(mentionChannelEnabled);
 		this.setMentionSlackUserEnabled(mentionSlackUserEnabled);
 		this.setMentionHereEnabled(mentionHereEnabled);
+		this.setMentionWhoTriggeredEnabled(mentionWhoTriggeredEnabled);
 
         if (!this.allBuildTypesEnabled) {
             this.enabledBuildTypesSet = enabledBuildTypes;
@@ -252,6 +260,7 @@ public class SlackNotificationConfig {
         el.setAttribute(CHANNEL_ENABLED_MESSAGE, String.valueOf(this.getMentionChannelEnabled()));
 		el.setAttribute(SLACK_USER_ENABLED_MESSAGE, String.valueOf(this.getMentionSlackUserEnabled()));
 		el.setAttribute(HERE_ENABLED_MESSAGE, String.valueOf(this.getMentionHereEnabled()));
+		el.setAttribute(WHO_TRIGGERED_ENABLED_MESSAGE, String.valueOf(this.isMentionWhoTriggeredEnabled()));
 
 		Element statesEl = new Element(STATES);
 		for (BuildStateEnum state : states.getStateSet()){
@@ -568,4 +577,13 @@ public class SlackNotificationConfig {
     public void setContent(SlackNotificationContentConfig content) {
         this.content = content;
     }
+
+	public boolean isMentionWhoTriggeredEnabled() {
+		return mentionWhoTriggeredEnabled;
+	}
+
+	public void setMentionWhoTriggeredEnabled(boolean mentionWhoTriggeredEnabled) {
+		this.mentionWhoTriggeredEnabled = mentionWhoTriggeredEnabled;
+	}
+
 }

--- a/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
+++ b/tcslackbuildnotifier-core/src/main/java/slacknotifications/teamcity/settings/SlackNotificationProjectSettings.java
@@ -132,7 +132,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
         }    	
     }
 
-	public void updateSlackNotification(String ProjectId, String token, String slackNotificationId, String channel, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, boolean mentionHereEnabled, SlackNotificationContentConfig content) {
+	public void updateSlackNotification(String ProjectId, String token, String slackNotificationId, String channel, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, boolean mentionHereEnabled, boolean mentionWhoTriggeredEnabled, SlackNotificationContentConfig content) {
         if(this.slackNotificationsConfigs != null)
         {
         	updateSuccess = false;
@@ -146,6 +146,7 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
                     whc.setMentionChannelEnabled(mentionChannelEnabled);
 					whc.setMentionSlackUserEnabled(mentionSlackUserEnabled);
 					whc.setMentionHereEnabled(mentionHereEnabled);
+					whc.setMentionWhoTriggeredEnabled(mentionWhoTriggeredEnabled);
                 	whc.setBuildStates(buildState);
                 	whc.enableForSubProjects(buildSubProjects);
                 	whc.enableForAllBuildsInProject(buildTypeAll);
@@ -164,8 +165,8 @@ public class SlackNotificationProjectSettings implements ProjectSettings {
         }    			
 	}
 
-	public void addNewSlackNotification(String ProjectId, String token, String channel, String teamName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildTypeSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, boolean mentionHereEnabled) {
-		this.slackNotificationsConfigs.add(new SlackNotificationConfig(token, channel, teamName, enabled, buildState, buildTypeAll, buildTypeSubProjects, buildTypesEnabled, mentionChannelEnabled, mentionSlackUserEnabled, mentionHereEnabled));
+	public void addNewSlackNotification(String ProjectId, String token, String channel, String teamName, Boolean enabled, BuildState buildState, boolean buildTypeAll, boolean buildTypeSubProjects, Set<String> buildTypesEnabled, boolean mentionChannelEnabled, boolean mentionSlackUserEnabled, boolean mentionHereEnabled, boolean mentionWhoTriggeredEnabled) {
+		this.slackNotificationsConfigs.add(new SlackNotificationConfig(token, channel, teamName, enabled, buildState, buildTypeAll, buildTypeSubProjects, buildTypesEnabled, mentionChannelEnabled, mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled));
 		Loggers.SERVER.debug(NAME + ":addNewSlackNotification :: Adding slack notifications to " + ProjectId + " with channel " + channel);
 		this.updateSuccess = true;
 	}

--- a/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
+++ b/tcslackbuildnotifier-core/src/test/java/slacknotifications/teamcity/SlackNotificationListenerTest.java
@@ -141,7 +141,7 @@ public class SlackNotificationListenerTest {
 	    BuildState buildState = new BuildState();
 	    SlackNotificationMainSettings mainSettings = new SlackNotificationMainSettings(sBuildServer, serverPaths);
 	    mainSettings.readFrom(getFullConfigElement());
-	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", true, buildState, true, true, null, true, true, true);
+	    SlackNotificationConfig config = new SlackNotificationConfig("", "#general", "teamName", true, buildState, true, true, null, true, true, true, true);
 	    SlackNotificationListener whl = new SlackNotificationListener(sBuildServer, settings, mainSettings, manager, factory);
 	    
 	    whl.getFromConfig(slackNotificationImpl, config);
@@ -173,7 +173,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildStartedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true);
+		projSettings.addNewSlackNotification("", "project1", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -184,7 +184,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildFinishedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state , true, true, new HashSet<String>(), true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state , true, true, new HashSet<String>(), true, true, true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.allEnabled());
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -198,7 +198,7 @@ public class SlackNotificationListenerTest {
 		state.enable(BuildStateEnum.BUILD_FIXED);
 		state.enable(BuildStateEnum.BUILD_FINISHED);
 		state.enable(BuildStateEnum.BUILD_SUCCESSFUL);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedFailedBuilds);
 		
@@ -210,7 +210,7 @@ public class SlackNotificationListenerTest {
 	public void testBuildFinishedSRunningBuildSuccessAfterSuccess() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BUILD_FIXED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true, true);
 		when(slacknotification.isEnabled()).thenReturn(state.enabled(BuildStateEnum.BUILD_FIXED));
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
@@ -221,7 +221,7 @@ public class SlackNotificationListenerTest {
 	@Test
 	public void testBuildInterruptedSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState().setAllEnabled();
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.buildInterrupted(sRunningBuild);
@@ -232,7 +232,7 @@ public class SlackNotificationListenerTest {
 	public void testBeforeBuildFinishSRunningBuild() throws FileNotFoundException, IOException {
 		BuildState state = new BuildState();
 		state.enable(BuildStateEnum.BEFORE_BUILD_FINISHED);
-		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true);
+		projSettings.addNewSlackNotification("", "1234", "my-channel", "myteam", true, state, true, true, new HashSet<String>(), true, true, true, true);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedSuccessfulBuilds);
 		
 		whl.beforeBuildFinish(sRunningBuild);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/SlackNotificationAjaxEditPageController.java
@@ -134,6 +134,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
                                         Boolean mentionChannelEnabled = false;
 										Boolean mentionSlackUserEnabled = false;
 										Boolean mentionHereEnabled = false;
+										Boolean mentionWhoTriggeredEnabled = false;
 			    						Boolean buildTypeAll = false;
 			    						Boolean buildTypeSubProjects = false;
                                         SlackNotificationContentConfig content = new SlackNotificationContentConfig();
@@ -154,6 +155,10 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 										if ((request.getParameter("mentionHereEnabled") != null )
 												&& ("on".equalsIgnoreCase(request.getParameter("mentionHereEnabled")))){
 											mentionHereEnabled = true;
+										}
+										if ((request.getParameter("mentionWhoTriggeredEnabled") != null )
+												&& ("on".equalsIgnoreCase(request.getParameter("mentionWhoTriggeredEnabled")))){
+											mentionWhoTriggeredEnabled = true;
 										}
 
                                         content.setEnabled((request.getParameter("customContentEnabled") != null )
@@ -223,7 +228,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 		    						
 			    						if ("new".equals(request.getParameter(SLACK_NOTIFICATION_ID))){
 			    							projSettings.addNewSlackNotification(myProject.getProjectId(), request.getParameter("token"), request.getParameter(CHANNEL), request.getParameter("team"), enabled,
-													states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled, mentionSlackUserEnabled, mentionHereEnabled);
+													states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled, mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled);
 			    							if(projSettings.updateSuccessful()){
 			    								myProject.persist();
 			    	    						params.put(MESSAGES, ERRORS_TAG);
@@ -234,7 +239,7 @@ public class SlackNotificationAjaxEditPageController extends BaseController {
 			    							projSettings.updateSlackNotification(myProject.getProjectId(), request.getParameter("token"),
                                                     request.getParameter(SLACK_NOTIFICATION_ID), request.getParameter(CHANNEL), enabled,
 													states, buildTypeAll, buildTypeSubProjects, buildTypes, mentionChannelEnabled,
-													mentionSlackUserEnabled, mentionHereEnabled, content);
+													mentionSlackUserEnabled, mentionHereEnabled, mentionWhoTriggeredEnabled, content);
 			    							if(projSettings.updateSuccessful()){
 			    								myProject.persist();
 			    	    						params.put(MESSAGES, ERRORS_TAG);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/ProjectSlackNotificationsBean.java
@@ -23,7 +23,7 @@ public class ProjectSlackNotificationsBean {
 		bean.slackNotificationList = new LinkedHashMap<String, SlacknotificationConfigAndBuildTypeListHolder>();
 
 		/* Create a "new" config with blank stuff so that clicking the "new" button has a bunch of defaults to load in */
-		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", true, new BuildState().setAllEnabled(), true, true, null, true, true, true);
+		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", true, new BuildState().setAllEnabled(), true, true, null, true, true, true, true);
 		newBlankConfig.setUniqueKey("new");
 		/* And add it to the list */
 		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig, mainSettings);
@@ -47,7 +47,7 @@ public class ProjectSlackNotificationsBean {
 		bean.slackNotificationList = new LinkedHashMap<String, SlacknotificationConfigAndBuildTypeListHolder>();
 		
 		/* Create a "new" config with blank stuff so that clicking the "new" button has a bunch of defaults to load in */
-		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", true, new BuildState().setAllEnabled(), false, false, enabledBuildTypes, true, true, true);
+		SlackNotificationConfig newBlankConfig = new SlackNotificationConfig("", "", "", true, new BuildState().setAllEnabled(), false, false, enabledBuildTypes, true, true, true, true);
 		newBlankConfig.setUniqueKey("new");
 		/* And add it to the list */
 		addSlackNotificationConfigHolder(bean, projectBuildTypes, newBlankConfig, mainSettings);

--- a/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
+++ b/tcslackbuildnotifier-web-ui/src/main/java/slacknotifications/teamcity/extension/bean/SlacknotificationConfigAndBuildTypeListHolder.java
@@ -30,6 +30,7 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
 	private boolean mentionChannelEnabled;
 	private boolean mentionSlackUserEnabled;
 	private boolean mentionHereEnabled;
+	private boolean mentionWhoTriggeredEnabled;
     private boolean customContentEnabled;
     private boolean showBuildAgent;
     private boolean showElapsedBuildTime;
@@ -56,6 +57,7 @@ public class SlacknotificationConfigAndBuildTypeListHolder {
 		mentionChannelEnabled = config.getMentionChannelEnabled();
 		mentionSlackUserEnabled = config.getMentionSlackUserEnabled();
 		mentionHereEnabled = config.getMentionHereEnabled();
+		mentionWhoTriggeredEnabled = config.isMentionWhoTriggeredEnabled();
         maxCommitsToDisplay = config.getContent().getMaxCommitsToDisplay();
         customContentEnabled = config.getContent().isEnabled();
         showBuildAgent = valueOrFallback(config.getContent().getShowBuildAgent(), valueOrFallback(mainSettings.getShowBuildAgent(), SlackNotificationContentConfig.DEFAULT_SHOW_BUILD_AGENT));

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/index.jsp
@@ -139,6 +139,7 @@
 					jQuerySlacknotification('#mentionChannelEnabled').attr('checked', slacknotification.mentionChannelEnabled);
 					jQuerySlacknotification('#mentionSlackUserEnabled').attr('checked', slacknotification.mentionSlackUserEnabled);
 					jQuerySlacknotification('#mentionHereEnabled').attr('checked', slacknotification.mentionHereEnabled);
+					jQuerySlacknotification('#mentionWhoTriggeredEnabled').attr('checked', slacknotification.mentionWhoTriggeredEnabled);
 					jQuerySlacknotification('#maxCommitsToDisplay').val(slacknotification.maxCommitsToDisplay);
 					jQuerySlacknotification('#customContentEnabled').attr('checked', slacknotification.customContentEnabled);
 					jQuerySlacknotification('#showBuildAgent').attr('checked', slacknotification.showBuildAgent);

--- a/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
+++ b/tcslackbuildnotifier-web-ui/src/main/resources/buildServerResources/SlackNotification/slackNotificationInclude.jsp
@@ -159,6 +159,10 @@
                                                          @here</label>
 													</td>
 												</tr>
+												<tr style="border:none;">
+													<td><label for="mentionWhoTriggeredEnabled">Mention who triggered:</label></td>
+													<td style="padding-left:3px;" colspan=2><input id="mentionWhoTriggeredEnabled" type=checkbox name="mentionWhoTriggeredEnabled"/></td>
+												</tr>
 					    					</table>     
 					    					
 					    			</div><!--hookPane -->


### PR DESCRIPTION
Introduce "Mention who triggered" feature and related setting. Now you can enable "Mention who triggered" option in Slack project config to add a mention of the person who triggered the build.

Also slack username was replaced with userid as currently Slack requires to use userid instead of just username for mentioning.

Should cover needed functionality for #147 